### PR TITLE
Remove print keyword and update documentation

### DIFF
--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -415,6 +415,8 @@ func TestKeywordRecognition(t *testing.T) {
 		{"go", TOKEN_GO},
 		{"defer", TOKEN_DEFER},
 		{"make", TOKEN_MAKE},
+		{"list", TOKEN_LIST},
+		{"map", TOKEN_MAP},
 		{"channel", TOKEN_CHANNEL},
 		{"send", TOKEN_SEND},
 		{"receive", TOKEN_RECEIVE},

--- a/internal/lexer/token.go
+++ b/internal/lexer/token.go
@@ -31,6 +31,8 @@ const (
 	TOKEN_GO
 	TOKEN_DEFER
 	TOKEN_MAKE
+	TOKEN_LIST
+	TOKEN_MAP
 	TOKEN_CHANNEL
 	TOKEN_SEND
 	TOKEN_RECEIVE
@@ -147,6 +149,10 @@ func (t TokenType) String() string {
 		return "DEFER"
 	case TOKEN_MAKE:
 		return "MAKE"
+	case TOKEN_LIST:
+		return "LIST"
+	case TOKEN_MAP:
+		return "MAP"
 	case TOKEN_CHANNEL:
 		return "CHANNEL"
 	case TOKEN_SEND:
@@ -281,6 +287,8 @@ var keywords = map[string]TokenType{
 	"go":        TOKEN_GO,
 	"defer":     TOKEN_DEFER,
 	"make":      TOKEN_MAKE,
+	"list":      TOKEN_LIST,
+	"map":       TOKEN_MAP,
 	"channel":   TOKEN_CHANNEL,
 	"send":      TOKEN_SEND,
 	"receive":   TOKEN_RECEIVE,

--- a/kukicha-grammar.ebnf.md
+++ b/kukicha-grammar.ebnf.md
@@ -363,11 +363,13 @@ leaf        import      type        interface   func
 if          else        for         in          from
 to          through     at          of          and
 or          not         return      go          defer
-make        channel     send        receive     close
-panic       recover     error       empty       reference
-on          this        discard     true        false
-equals      as
+make        list        map         channel     send
+receive     close       panic       recover     error
+empty       reference   on          this        discard
+true        false       equals      as
 ```
+
+**Note:** The keywords `list`, `map`, and `channel` are context-sensitive and may also be used as identifiers in certain contexts.
 
 ---
 


### PR DESCRIPTION
…not keyword

As per kukicha-stdlib-roadmap.md, print is a standard library function, not a keyword. This commit reviews language changes since lexer implementation and updates the lexer.

Changes:
1. Added missing keywords to lexer:
   - TOKEN_LIST and TOKEN_MAP (context-sensitive keywords from grammar)
   - These were defined in documentation but never implemented in lexer

2. Updated grammar documentation:
   - Added list and map to reserved keywords list in kukicha-grammar.ebnf.md
   - Added note about context-sensitive nature of list, map, and channel

3. Added tests for new keywords:
   - Added list and map keyword recognition tests
   - All lexer tests pass

4. Verified print is NOT a keyword:
   - Confirmed print is correctly treated as identifier/function
   - No TOKEN_PRINT exists (correct behavior)
   - Tests show print tokenizes as TOKEN_IDENTIFIER

5. Reviewed commits since lexer implementation:
   - Membership operators (in, not in): already supported
   - Negative indexing: lexer-agnostic (handled by parser)
   - All documented language features reflected in lexer

All tests pass. Lexer now matches current grammar specification.