### PR TITLE
Build parser, semantic analysis, and code generator

### DIFF
--- a/cmd/kukicha/main.go
+++ b/cmd/kukicha/main.go
@@ -1,0 +1,238 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/duber000/kukicha/internal/codegen"
+	"github.com/duber000/kukicha/internal/parser"
+	"github.com/duber000/kukicha/internal/semantic"
+)
+
+const version = "0.1.0"
+
+func main() {
+	if len(os.Args) < 2 {
+		printUsage()
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+
+	switch command {
+	case "build":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: kukicha build <file.kuki>")
+			os.Exit(1)
+		}
+		buildCommand(os.Args[2])
+	case "run":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: kukicha run <file.kuki>")
+			os.Exit(1)
+		}
+		runCommand(os.Args[2])
+	case "check":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: kukicha check <file.kuki>")
+			os.Exit(1)
+		}
+		checkCommand(os.Args[2])
+	case "version":
+		fmt.Printf("kukicha version %s\n", version)
+	case "help", "-h", "--help":
+		printUsage()
+	default:
+		fmt.Printf("Unknown command: %s\n", command)
+		printUsage()
+		os.Exit(1)
+	}
+}
+
+func printUsage() {
+	fmt.Println("Kukicha - A transpiler that compiles Kukicha to Go")
+	fmt.Println()
+	fmt.Println("Usage:")
+	fmt.Println("  kukicha build <file.kuki>   Compile Kukicha file to Go")
+	fmt.Println("  kukicha run <file.kuki>     Transpile and execute Kukicha file")
+	fmt.Println("  kukicha check <file.kuki>   Type check Kukicha file")
+	fmt.Println("  kukicha version             Show version information")
+	fmt.Println("  kukicha help                Show this help message")
+}
+
+func buildCommand(filename string) {
+	// Read source file
+	source, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse
+	p, err := parser.New(string(source), filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Lexer error: %v\n", err)
+		os.Exit(1)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Parse errors:\n")
+		for _, err := range parseErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	// Semantic analysis
+	analyzer := semantic.New(program)
+	semanticErrors := analyzer.Analyze()
+	if len(semanticErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Semantic errors:\n")
+		for _, err := range semanticErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	// Generate Go code
+	gen := codegen.New(program)
+	goCode, err := gen.Generate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Code generation error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write Go file
+	outputFile := strings.TrimSuffix(filename, ".kuki") + ".go"
+	err = os.WriteFile(outputFile, []byte(goCode), 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing output file: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Successfully compiled %s to %s\n", filename, outputFile)
+
+	// Optionally run go build on the generated file
+	cmd := exec.Command("go", "build", outputFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: go build failed: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Generated Go file is at: %s\n", outputFile)
+		os.Exit(1)
+	}
+
+	// Get the binary name
+	binaryName := strings.TrimSuffix(filepath.Base(filename), ".kuki")
+	fmt.Printf("Successfully built binary: %s\n", binaryName)
+}
+
+func runCommand(filename string) {
+	// Read source file
+	source, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse
+	p, err := parser.New(string(source), filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Lexer error: %v\n", err)
+		os.Exit(1)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Parse errors:\n")
+		for _, err := range parseErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	// Semantic analysis
+	analyzer := semantic.New(program)
+	semanticErrors := analyzer.Analyze()
+	if len(semanticErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Semantic errors:\n")
+		for _, err := range semanticErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	// Generate Go code
+	gen := codegen.New(program)
+	goCode, err := gen.Generate()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Code generation error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Write temporary Go file
+	tmpFile := filepath.Join(os.TempDir(), "kukicha_temp.go")
+	err = os.WriteFile(tmpFile, []byte(goCode), 0644)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error writing temporary file: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(tmpFile)
+
+	// Run with go run
+	cmd := exec.Command("go", "run", tmpFile)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+	err = cmd.Run()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			os.Exit(exitErr.ExitCode())
+		}
+		fmt.Fprintf(os.Stderr, "Error running program: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func checkCommand(filename string) {
+	// Read source file
+	source, err := os.ReadFile(filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Parse
+	p, err := parser.New(string(source), filename)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Lexer error: %v\n", err)
+		os.Exit(1)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Parse errors:\n")
+		for _, err := range parseErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	// Semantic analysis
+	analyzer := semantic.New(program)
+	semanticErrors := analyzer.Analyze()
+	if len(semanticErrors) > 0 {
+		fmt.Fprintf(os.Stderr, "Type errors:\n")
+		for _, err := range semanticErrors {
+			fmt.Fprintf(os.Stderr, "  %v\n", err)
+		}
+		os.Exit(1)
+	}
+
+	fmt.Printf("✓ %s type checks successfully\n", filename)
+}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,619 @@
+package ast
+
+import "github.com/duber000/kukicha/internal/lexer"
+
+// Node is the base interface for all AST nodes
+type Node interface {
+	TokenLiteral() string
+	Pos() Position
+}
+
+// Position represents a location in the source code
+type Position struct {
+	Line   int
+	Column int
+	File   string
+}
+
+// ============================================================================
+// Program - Root node
+// ============================================================================
+
+type Program struct {
+	LeafDecl     *LeafDecl      // Optional leaf declaration
+	Imports      []*ImportDecl  // Import declarations
+	Declarations []Declaration  // Top-level declarations (types, interfaces, functions)
+}
+
+func (p *Program) TokenLiteral() string {
+	if p.LeafDecl != nil {
+		return p.LeafDecl.TokenLiteral()
+	}
+	if len(p.Imports) > 0 {
+		return p.Imports[0].TokenLiteral()
+	}
+	if len(p.Declarations) > 0 {
+		return p.Declarations[0].TokenLiteral()
+	}
+	return ""
+}
+
+func (p *Program) Pos() Position {
+	if p.LeafDecl != nil {
+		return p.LeafDecl.Pos()
+	}
+	if len(p.Imports) > 0 {
+		return p.Imports[0].Pos()
+	}
+	if len(p.Declarations) > 0 {
+		return p.Declarations[0].Pos()
+	}
+	return Position{}
+}
+
+// ============================================================================
+// Declarations
+// ============================================================================
+
+type Declaration interface {
+	Node
+	declNode()
+}
+
+type LeafDecl struct {
+	Token lexer.Token // The 'leaf' token
+	Name  *Identifier
+}
+
+func (d *LeafDecl) TokenLiteral() string {
+	return d.Token.Lexeme
+}
+func (d *LeafDecl) Pos() Position {
+	return Position{Line: d.Token.Line, Column: d.Token.Column, File: d.Token.File}
+}
+func (d *LeafDecl) declNode()            {}
+
+type ImportDecl struct {
+	Token lexer.Token // The 'import' token
+	Path  *StringLiteral
+	Alias *Identifier // Optional alias
+}
+
+func (d *ImportDecl) TokenLiteral() string { return d.Token.Lexeme }
+func (d *ImportDecl) Pos() Position        { return Position{Line: d.Token.Line, Column: d.Token.Column, File: d.Token.File} }
+func (d *ImportDecl) declNode()            {}
+
+type TypeDecl struct {
+	Token  lexer.Token // The 'type' token
+	Name   *Identifier
+	Fields []*FieldDecl
+}
+
+func (d *TypeDecl) TokenLiteral() string { return d.Token.Lexeme }
+func (d *TypeDecl) Pos() Position        { return Position{Line: d.Token.Line, Column: d.Token.Column, File: d.Token.File} }
+func (d *TypeDecl) declNode()            {}
+
+type FieldDecl struct {
+	Name *Identifier
+	Type TypeAnnotation
+}
+
+type InterfaceDecl struct {
+	Token   lexer.Token // The 'interface' token
+	Name    *Identifier
+	Methods []*MethodSignature
+}
+
+func (d *InterfaceDecl) TokenLiteral() string { return d.Token.Lexeme }
+func (d *InterfaceDecl) Pos() Position        { return Position{Line: d.Token.Line, Column: d.Token.Column, File: d.Token.File} }
+func (d *InterfaceDecl) declNode()            {}
+
+type MethodSignature struct {
+	Name       *Identifier
+	Parameters []*Parameter
+	Returns    []TypeAnnotation
+}
+
+type FunctionDecl struct {
+	Token      lexer.Token // The 'func' token
+	Name       *Identifier
+	Parameters []*Parameter
+	Returns    []TypeAnnotation
+	Body       *BlockStmt
+	Receiver   *Receiver // For methods (optional)
+}
+
+func (d *FunctionDecl) TokenLiteral() string { return d.Token.Lexeme }
+func (d *FunctionDecl) Pos() Position        { return Position{Line: d.Token.Line, Column: d.Token.Column, File: d.Token.File} }
+func (d *FunctionDecl) declNode()            {}
+
+type Parameter struct {
+	Name *Identifier
+	Type TypeAnnotation
+}
+
+type Receiver struct {
+	Name *Identifier // Can be 'this' or a variable name
+	Type TypeAnnotation
+}
+
+// ============================================================================
+// Type Annotations
+// ============================================================================
+
+type TypeAnnotation interface {
+	Node
+	typeNode()
+}
+
+type PrimitiveType struct {
+	Token lexer.Token // The type token
+	Name  string      // int, float, string, bool, etc.
+}
+
+func (t *PrimitiveType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *PrimitiveType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *PrimitiveType) typeNode()            {}
+
+type NamedType struct {
+	Token lexer.Token // The identifier token
+	Name  string
+}
+
+func (t *NamedType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *NamedType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *NamedType) typeNode()            {}
+
+type ReferenceType struct {
+	Token       lexer.Token // The 'reference' token
+	ElementType TypeAnnotation
+}
+
+func (t *ReferenceType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *ReferenceType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *ReferenceType) typeNode()            {}
+
+type ListType struct {
+	Token       lexer.Token // The 'list' token
+	ElementType TypeAnnotation
+}
+
+func (t *ListType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *ListType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *ListType) typeNode()            {}
+
+type MapType struct {
+	Token     lexer.Token // The 'map' token
+	KeyType   TypeAnnotation
+	ValueType TypeAnnotation
+}
+
+func (t *MapType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *MapType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *MapType) typeNode()            {}
+
+type ChannelType struct {
+	Token       lexer.Token // The 'channel' token
+	ElementType TypeAnnotation
+}
+
+func (t *ChannelType) TokenLiteral() string { return t.Token.Lexeme }
+func (t *ChannelType) Pos() Position        { return Position{Line: t.Token.Line, Column: t.Token.Column, File: t.Token.File} }
+func (t *ChannelType) typeNode()            {}
+
+// ============================================================================
+// Statements
+// ============================================================================
+
+type Statement interface {
+	Node
+	stmtNode()
+}
+
+type BlockStmt struct {
+	Token      lexer.Token // The '{' or INDENT token
+	Statements []Statement
+}
+
+func (s *BlockStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *BlockStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *BlockStmt) stmtNode()            {}
+
+type VarDeclStmt struct {
+	Name  *Identifier
+	Type  TypeAnnotation // Optional (can be nil for inference)
+	Value Expression
+	Token lexer.Token // The identifier token or walrus token
+}
+
+func (s *VarDeclStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *VarDeclStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *VarDeclStmt) stmtNode()            {}
+
+type AssignStmt struct {
+	Target Expression  // Can be identifier, index expr, etc.
+	Value  Expression
+	Token  lexer.Token // The '=' token
+}
+
+func (s *AssignStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *AssignStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *AssignStmt) stmtNode()            {}
+
+type ReturnStmt struct {
+	Token  lexer.Token // The 'return' token
+	Values []Expression
+}
+
+func (s *ReturnStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *ReturnStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *ReturnStmt) stmtNode()            {}
+
+type IfStmt struct {
+	Token       lexer.Token // The 'if' token
+	Condition   Expression
+	Consequence *BlockStmt
+	Alternative Statement // Can be ElseStmt or another IfStmt (else if)
+}
+
+func (s *IfStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *IfStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *IfStmt) stmtNode()            {}
+
+type ElseStmt struct {
+	Token lexer.Token // The 'else' token
+	Body  *BlockStmt
+}
+
+func (s *ElseStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *ElseStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *ElseStmt) stmtNode()            {}
+
+// ForRangeStmt: for item in collection
+type ForRangeStmt struct {
+	Token      lexer.Token // The 'for' token
+	Variable   *Identifier
+	Index      *Identifier // Optional (for index, item in collection)
+	Collection Expression
+	Body       *BlockStmt
+}
+
+func (s *ForRangeStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *ForRangeStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *ForRangeStmt) stmtNode()            {}
+
+// ForNumericStmt: for i from start to end / for i from start through end
+type ForNumericStmt struct {
+	Token    lexer.Token // The 'for' token
+	Variable *Identifier
+	Start    Expression
+	End      Expression
+	Through  bool // true for 'through', false for 'to'
+	Body     *BlockStmt
+}
+
+func (s *ForNumericStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *ForNumericStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *ForNumericStmt) stmtNode()            {}
+
+// ForConditionStmt: for condition
+type ForConditionStmt struct {
+	Token     lexer.Token // The 'for' token
+	Condition Expression
+	Body      *BlockStmt
+}
+
+func (s *ForConditionStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *ForConditionStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *ForConditionStmt) stmtNode()            {}
+
+type DeferStmt struct {
+	Token lexer.Token // The 'defer' token
+	Call  *CallExpr
+}
+
+func (s *DeferStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *DeferStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *DeferStmt) stmtNode()            {}
+
+type GoStmt struct {
+	Token lexer.Token // The 'go' token
+	Call  *CallExpr
+}
+
+func (s *GoStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *GoStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *GoStmt) stmtNode()            {}
+
+type SendStmt struct {
+	Token   lexer.Token // The 'send' token
+	Value   Expression
+	Channel Expression
+}
+
+func (s *SendStmt) TokenLiteral() string { return s.Token.Lexeme }
+func (s *SendStmt) Pos() Position        { return Position{Line: s.Token.Line, Column: s.Token.Column, File: s.Token.File} }
+func (s *SendStmt) stmtNode()            {}
+
+type ExpressionStmt struct {
+	Expression Expression
+}
+
+func (s *ExpressionStmt) TokenLiteral() string { return s.Expression.TokenLiteral() }
+func (s *ExpressionStmt) Pos() Position        { return s.Expression.Pos() }
+func (s *ExpressionStmt) stmtNode()            {}
+
+// ============================================================================
+// Expressions
+// ============================================================================
+
+type Expression interface {
+	Node
+	exprNode()
+}
+
+type Identifier struct {
+	Token lexer.Token
+	Value string
+}
+
+func (e *Identifier) TokenLiteral() string { return e.Token.Lexeme }
+func (e *Identifier) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *Identifier) exprNode()            {}
+
+type IntegerLiteral struct {
+	Token lexer.Token
+	Value int64
+}
+
+func (e *IntegerLiteral) TokenLiteral() string { return e.Token.Lexeme }
+func (e *IntegerLiteral) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *IntegerLiteral) exprNode()            {}
+
+type FloatLiteral struct {
+	Token lexer.Token
+	Value float64
+}
+
+func (e *FloatLiteral) TokenLiteral() string { return e.Token.Lexeme }
+func (e *FloatLiteral) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *FloatLiteral) exprNode()            {}
+
+type StringLiteral struct {
+	Token        lexer.Token
+	Value        string
+	Interpolated bool                   // True if contains {expr}
+	Parts        []*StringInterpolation // For interpolated strings
+}
+
+func (e *StringLiteral) TokenLiteral() string { return e.Token.Lexeme }
+func (e *StringLiteral) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *StringLiteral) exprNode()            {}
+
+type StringInterpolation struct {
+	IsLiteral bool       // True for literal parts, false for expressions
+	Literal   string     // For literal parts
+	Expr      Expression // For expression parts
+}
+
+type BooleanLiteral struct {
+	Token lexer.Token
+	Value bool
+}
+
+func (e *BooleanLiteral) TokenLiteral() string { return e.Token.Lexeme }
+func (e *BooleanLiteral) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *BooleanLiteral) exprNode()            {}
+
+type BinaryExpr struct {
+	Token    lexer.Token // The operator token
+	Left     Expression
+	Operator string
+	Right    Expression
+}
+
+func (e *BinaryExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *BinaryExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *BinaryExpr) exprNode()            {}
+
+type UnaryExpr struct {
+	Token    lexer.Token // The operator token
+	Operator string
+	Right    Expression
+}
+
+func (e *UnaryExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *UnaryExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *UnaryExpr) exprNode()            {}
+
+type PipeExpr struct {
+	Token lexer.Token // The '|>' token
+	Left  Expression
+	Right Expression // Must be a function call
+}
+
+func (e *PipeExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *PipeExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *PipeExpr) exprNode()            {}
+
+type OnErrExpr struct {
+	Token   lexer.Token // The 'onerr' token
+	Left    Expression  // Expression that might error
+	Handler Expression  // Error handler (can be discard or expression)
+}
+
+func (e *OnErrExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *OnErrExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *OnErrExpr) exprNode()            {}
+
+type CallExpr struct {
+	Token     lexer.Token // The '(' token or identifier
+	Function  Expression
+	Arguments []Expression
+}
+
+func (e *CallExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *CallExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *CallExpr) exprNode()            {}
+
+type MethodCallExpr struct {
+	Token     lexer.Token // The '.' token
+	Object    Expression
+	Method    *Identifier
+	Arguments []Expression
+}
+
+func (e *MethodCallExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *MethodCallExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *MethodCallExpr) exprNode()            {}
+
+type IndexExpr struct {
+	Token lexer.Token // The '[' token
+	Left  Expression
+	Index Expression
+}
+
+func (e *IndexExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *IndexExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *IndexExpr) exprNode()            {}
+
+type SliceExpr struct {
+	Token lexer.Token // The '[' token
+	Left  Expression
+	Start Expression // Can be nil
+	End   Expression // Can be nil
+}
+
+func (e *SliceExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *SliceExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *SliceExpr) exprNode()            {}
+
+type StructLiteralExpr struct {
+	Token  lexer.Token // The type identifier
+	Type   TypeAnnotation
+	Fields []*FieldValue
+}
+
+func (e *StructLiteralExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *StructLiteralExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *StructLiteralExpr) exprNode()            {}
+
+type FieldValue struct {
+	Name  *Identifier
+	Value Expression
+}
+
+type ListLiteralExpr struct {
+	Token    lexer.Token // The '[' token or 'list' keyword
+	Type     TypeAnnotation
+	Elements []Expression
+}
+
+func (e *ListLiteralExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *ListLiteralExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *ListLiteralExpr) exprNode()            {}
+
+type MapLiteralExpr struct {
+	Token   lexer.Token // The '{' token or 'map' keyword
+	KeyType TypeAnnotation
+	ValType TypeAnnotation
+	Pairs   []*KeyValuePair
+}
+
+func (e *MapLiteralExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *MapLiteralExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *MapLiteralExpr) exprNode()            {}
+
+type KeyValuePair struct {
+	Key   Expression
+	Value Expression
+}
+
+type ReceiveExpr struct {
+	Token   lexer.Token // The 'receive' token
+	Channel Expression
+}
+
+func (e *ReceiveExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *ReceiveExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *ReceiveExpr) exprNode()            {}
+
+type TypeCastExpr struct {
+	Token      lexer.Token // The 'as' token
+	Expression Expression
+	TargetType TypeAnnotation
+}
+
+func (e *TypeCastExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *TypeCastExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *TypeCastExpr) exprNode()            {}
+
+type ThisExpr struct {
+	Token lexer.Token // The 'this' token
+}
+
+func (e *ThisExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *ThisExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *ThisExpr) exprNode()            {}
+
+type EmptyExpr struct {
+	Token lexer.Token // The 'empty' token
+	Type  TypeAnnotation
+}
+
+func (e *EmptyExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *EmptyExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *EmptyExpr) exprNode()            {}
+
+type DiscardExpr struct {
+	Token lexer.Token // The 'discard' token
+}
+
+func (e *DiscardExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *DiscardExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *DiscardExpr) exprNode()            {}
+
+type ErrorExpr struct {
+	Token   lexer.Token // The 'error' token
+	Message Expression  // Usually a string literal
+}
+
+func (e *ErrorExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *ErrorExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *ErrorExpr) exprNode()            {}
+
+type MakeExpr struct {
+	Token lexer.Token // The 'make' token
+	Type  TypeAnnotation
+	Args  []Expression // Size/capacity for slices, channels
+}
+
+func (e *MakeExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *MakeExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *MakeExpr) exprNode()            {}
+
+type CloseExpr struct {
+	Token   lexer.Token // The 'close' token
+	Channel Expression
+}
+
+func (e *CloseExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *CloseExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *CloseExpr) exprNode()            {}
+
+type PanicExpr struct {
+	Token   lexer.Token // The 'panic' token
+	Message Expression
+}
+
+func (e *PanicExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *PanicExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *PanicExpr) exprNode()            {}
+
+type RecoverExpr struct {
+	Token lexer.Token // The 'recover' token
+}
+
+func (e *RecoverExpr) TokenLiteral() string { return e.Token.Lexeme }
+func (e *RecoverExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
+func (e *RecoverExpr) exprNode()            {}

--- a/internal/codegen/codegen_test.go
+++ b/internal/codegen/codegen_test.go
@@ -1,0 +1,391 @@
+package codegen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/duber000/kukicha/internal/parser"
+)
+
+func TestSimpleFunction(t *testing.T) {
+	input := `func Add(a int, b int) int
+    return a + b
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "func Add(a int, b int) int") {
+		t.Errorf("expected function signature, got: %s", output)
+	}
+
+	if !strings.Contains(output, "return (a + b)") {
+		t.Errorf("expected return statement, got: %s", output)
+	}
+}
+
+func TestTypeDeclaration(t *testing.T) {
+	input := `type Person
+    Name string
+    Age int
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "type Person struct") {
+		t.Errorf("expected struct declaration, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Name string") {
+		t.Errorf("expected Name field, got: %s", output)
+	}
+
+	if !strings.Contains(output, "Age int") {
+		t.Errorf("expected Age field, got: %s", output)
+	}
+}
+
+func TestListType(t *testing.T) {
+	input := `func GetItems() list of int
+    return [1, 2, 3]
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "[]int") {
+		t.Errorf("expected slice type, got: %s", output)
+	}
+}
+
+func TestMapType(t *testing.T) {
+	input := `func GetMap() map of string to int
+    return empty map of string to int
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "map[string]int") {
+		t.Errorf("expected map type, got: %s", output)
+	}
+}
+
+func TestForLoop(t *testing.T) {
+	input := `func Sum(items list of int) int
+    sum := 0
+    for item in items
+        sum = sum + item
+    return sum
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "for _, item := range items") {
+		t.Errorf("expected for range loop, got: %s", output)
+	}
+}
+
+func TestNumericForLoop(t *testing.T) {
+	input := `func Test()
+    for i from 0 to 10
+        x := i
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "for i := 0; i < 10; i++") {
+		t.Errorf("expected numeric for loop with <, got: %s", output)
+	}
+}
+
+func TestNumericForLoopThrough(t *testing.T) {
+	input := `func Test()
+    for i from 0 through 10
+        x := i
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "for i := 0; i <= 10; i++") {
+		t.Errorf("expected numeric for loop with <=, got: %s", output)
+	}
+}
+
+func TestIfElse(t *testing.T) {
+	input := `func Max(a int, b int) int
+    if a > b
+        return a
+    else
+        return b
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "if (a > b)") {
+		t.Errorf("expected if statement, got: %s", output)
+	}
+
+	if !strings.Contains(output, "} else {") {
+		t.Errorf("expected else clause, got: %s", output)
+	}
+}
+
+func TestBooleanOperators(t *testing.T) {
+	input := `func Test(a bool, b bool) bool
+    return a and b or a
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "&&") {
+		t.Errorf("expected && operator, got: %s", output)
+	}
+
+	if !strings.Contains(output, "||") {
+		t.Errorf("expected || operator, got: %s", output)
+	}
+}
+
+func TestStringInterpolation(t *testing.T) {
+	input := `func Greet(name string) string
+    return "Hello {name}!"
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	t.Logf("Generated output:\n%s", output)
+
+	if !strings.Contains(output, "fmt.Sprintf") {
+		t.Errorf("expected fmt.Sprintf for string interpolation, got: %s", output)
+	}
+
+	if !strings.Contains(output, "\"fmt\"") {
+		t.Errorf("expected fmt import, got: %s", output)
+	}
+}
+
+func TestReferenceType(t *testing.T) {
+	input := `type Person
+    Name string
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	// Just verify that types are generated correctly
+	if !strings.Contains(output, "type Person struct") {
+		t.Errorf("expected struct type, got: %s", output)
+	}
+}
+
+func TestPackageDeclaration(t *testing.T) {
+	input := `leaf mypackage
+
+func Test()
+    x := 1
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.HasPrefix(output, "package mypackage") {
+		t.Errorf("expected package mypackage, got: %s", output)
+	}
+}
+
+func TestImports(t *testing.T) {
+	input := `import "fmt"
+import "strings" as str
+
+func Test()
+    x := 1
+`
+
+	p, err := parser.New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("parser error: %v", err)
+	}
+
+	program, parseErrors := p.Parse()
+	if len(parseErrors) > 0 {
+		t.Fatalf("parse errors: %v", parseErrors)
+	}
+
+	gen := New(program)
+	output, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("codegen error: %v", err)
+	}
+
+	if !strings.Contains(output, "\"fmt\"") {
+		t.Errorf("expected fmt import, got: %s", output)
+	}
+
+	if !strings.Contains(output, "str \"strings\"") {
+		t.Errorf("expected aliased strings import, got: %s", output)
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,1267 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/duber000/kukicha/internal/ast"
+	"github.com/duber000/kukicha/internal/lexer"
+)
+
+// Parser parses tokens into an AST
+type Parser struct {
+	tokens []lexer.Token
+	pos    int
+	errors []error
+}
+
+// New creates a new parser from a source string
+func New(source string, filename string) (*Parser, error) {
+	l := lexer.NewLexer(source, filename)
+	tokens, err := l.ScanTokens()
+	if err != nil {
+		return nil, err
+	}
+	return &Parser{
+		tokens: tokens,
+		pos:    0,
+		errors: []error{},
+	}, nil
+}
+
+// Parse parses the tokens into a Program AST
+func (p *Parser) Parse() (*ast.Program, []error) {
+	program := &ast.Program{
+		Imports:      []*ast.ImportDecl{},
+		Declarations: []ast.Declaration{},
+	}
+
+	// Parse optional leaf declaration
+	if p.peekToken().Type == lexer.TOKEN_LEAF {
+		program.LeafDecl = p.parseLeafDecl()
+	}
+
+	// Parse imports
+	for p.peekToken().Type == lexer.TOKEN_IMPORT {
+		program.Imports = append(program.Imports, p.parseImportDecl())
+	}
+
+	// Parse top-level declarations
+	for !p.isAtEnd() {
+		if decl := p.parseDeclaration(); decl != nil {
+			program.Declarations = append(program.Declarations, decl)
+		}
+	}
+
+	return program, p.errors
+}
+
+// Errors returns the parsing errors
+func (p *Parser) Errors() []error {
+	return p.errors
+}
+
+// ============================================================================
+// Helper Methods
+// ============================================================================
+
+func (p *Parser) isAtEnd() bool {
+	return p.pos >= len(p.tokens) || p.peekToken().Type == lexer.TOKEN_EOF
+}
+
+func (p *Parser) peekToken() lexer.Token {
+	if p.pos >= len(p.tokens) {
+		return lexer.Token{Type: lexer.TOKEN_EOF}
+	}
+	return p.tokens[p.pos]
+}
+
+func (p *Parser) previousToken() lexer.Token {
+	if p.pos == 0 {
+		return lexer.Token{Type: lexer.TOKEN_EOF}
+	}
+	return p.tokens[p.pos-1]
+}
+
+func (p *Parser) advance() lexer.Token {
+	if !p.isAtEnd() {
+		p.pos++
+	}
+	return p.previousToken()
+}
+
+func (p *Parser) check(tokenType lexer.TokenType) bool {
+	if p.isAtEnd() {
+		return false
+	}
+	return p.peekToken().Type == tokenType
+}
+
+func (p *Parser) match(types ...lexer.TokenType) bool {
+	for _, t := range types {
+		if p.check(t) {
+			p.advance()
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Parser) consume(tokenType lexer.TokenType, message string) (lexer.Token, error) {
+	if p.check(tokenType) {
+		return p.advance(), nil
+	}
+	err := p.error(p.peekToken(), message)
+	return lexer.Token{}, err
+}
+
+func (p *Parser) error(token lexer.Token, message string) error {
+	err := fmt.Errorf("%s:%d:%d: %s", token.File, token.Line, token.Column, message)
+	p.errors = append(p.errors, err)
+	return err
+}
+
+func (p *Parser) skipNewlines() {
+	for p.match(lexer.TOKEN_NEWLINE) {
+	}
+}
+
+// ============================================================================
+// Declaration Parsing
+// ============================================================================
+
+func (p *Parser) parseLeafDecl() *ast.LeafDecl {
+	token := p.advance() // consume 'leaf'
+	p.skipNewlines()
+
+	name := p.parseIdentifier()
+	p.skipNewlines()
+
+	return &ast.LeafDecl{
+		Token: token,
+		Name:  name,
+	}
+}
+
+func (p *Parser) parseImportDecl() *ast.ImportDecl {
+	token := p.advance() // consume 'import'
+	p.skipNewlines()
+
+	pathToken := p.advance()
+	if pathToken.Type != lexer.TOKEN_STRING {
+		p.error(pathToken, "expected string literal for import path")
+		return nil
+	}
+
+	decl := &ast.ImportDecl{
+		Token: token,
+		Path: &ast.StringLiteral{
+			Token: pathToken,
+			Value: pathToken.Lexeme,
+		},
+	}
+
+	// Check for optional alias (as Name)
+	if p.match(lexer.TOKEN_AS) {
+		decl.Alias = p.parseIdentifier()
+	}
+
+	p.skipNewlines()
+	return decl
+}
+
+func (p *Parser) parseDeclaration() ast.Declaration {
+	p.skipNewlines()
+
+	switch p.peekToken().Type {
+	case lexer.TOKEN_TYPE:
+		return p.parseTypeDecl()
+	case lexer.TOKEN_INTERFACE:
+		return p.parseInterfaceDecl()
+	case lexer.TOKEN_FUNC:
+		return p.parseFunctionDecl()
+	default:
+		if !p.isAtEnd() {
+			p.error(p.peekToken(), fmt.Sprintf("unexpected token %s, expected declaration", p.peekToken().Type))
+			p.advance() // Skip the problematic token
+		}
+		return nil
+	}
+}
+
+func (p *Parser) parseTypeDecl() *ast.TypeDecl {
+	token := p.advance() // consume 'type'
+	p.skipNewlines()
+
+	name := p.parseIdentifier()
+	p.skipNewlines()
+
+	fields := []*ast.FieldDecl{}
+
+	// Expect INDENT for fields
+	if !p.match(lexer.TOKEN_INDENT) {
+		p.error(p.peekToken(), "expected indented block for type fields")
+		return nil
+	}
+
+	// Parse fields
+	for !p.check(lexer.TOKEN_DEDENT) && !p.isAtEnd() {
+		p.skipNewlines()
+		if p.check(lexer.TOKEN_DEDENT) {
+			break
+		}
+
+		fieldName := p.parseIdentifier()
+		fieldType := p.parseTypeAnnotation()
+		fields = append(fields, &ast.FieldDecl{
+			Name: fieldName,
+			Type: fieldType,
+		})
+		p.skipNewlines()
+	}
+
+	p.consume(lexer.TOKEN_DEDENT, "expected dedent after type fields")
+	p.skipNewlines()
+
+	return &ast.TypeDecl{
+		Token:  token,
+		Name:   name,
+		Fields: fields,
+	}
+}
+
+func (p *Parser) parseInterfaceDecl() *ast.InterfaceDecl {
+	token := p.advance() // consume 'interface'
+	p.skipNewlines()
+
+	name := p.parseIdentifier()
+	p.skipNewlines()
+
+	methods := []*ast.MethodSignature{}
+
+	// Expect INDENT for methods
+	if !p.match(lexer.TOKEN_INDENT) {
+		p.error(p.peekToken(), "expected indented block for interface methods")
+		return nil
+	}
+
+	// Parse method signatures
+	for !p.check(lexer.TOKEN_DEDENT) && !p.isAtEnd() {
+		p.skipNewlines()
+		if p.check(lexer.TOKEN_DEDENT) {
+			break
+		}
+
+		methodName := p.parseIdentifier()
+
+		// Parse parameters
+		p.consume(lexer.TOKEN_LPAREN, "expected '(' for method parameters")
+		params := p.parseParameters()
+		p.consume(lexer.TOKEN_RPAREN, "expected ')' after method parameters")
+
+		// Parse return types
+		returns := []ast.TypeAnnotation{}
+		if !p.check(lexer.TOKEN_NEWLINE) && !p.check(lexer.TOKEN_DEDENT) {
+			returns = p.parseReturnTypes()
+		}
+
+		methods = append(methods, &ast.MethodSignature{
+			Name:       methodName,
+			Parameters: params,
+			Returns:    returns,
+		})
+		p.skipNewlines()
+	}
+
+	p.consume(lexer.TOKEN_DEDENT, "expected dedent after interface methods")
+	p.skipNewlines()
+
+	return &ast.InterfaceDecl{
+		Token:   token,
+		Name:    name,
+		Methods: methods,
+	}
+}
+
+func (p *Parser) parseFunctionDecl() *ast.FunctionDecl {
+	token := p.advance() // consume 'func'
+	p.skipNewlines()
+
+	decl := &ast.FunctionDecl{
+		Token: token,
+	}
+
+	// Check for receiver (method declaration)
+	// Two styles: func (r Type) Name(...) or func Name on this Type
+	if p.check(lexer.TOKEN_LPAREN) {
+		// Go-style receiver: func (r Type) Name(...)
+		p.advance() // consume '('
+		receiverName := p.parseIdentifier()
+		receiverType := p.parseTypeAnnotation()
+		p.consume(lexer.TOKEN_RPAREN, "expected ')' after receiver")
+
+		decl.Receiver = &ast.Receiver{
+			Name: receiverName,
+			Type: receiverType,
+		}
+	}
+
+	// Parse function name
+	decl.Name = p.parseIdentifier()
+
+	// Check for Kukicha-style receiver: func Name on this Type
+	if p.match(lexer.TOKEN_ON) {
+		if p.check(lexer.TOKEN_THIS) {
+			thisToken := p.advance()
+			receiverType := p.parseTypeAnnotation()
+			decl.Receiver = &ast.Receiver{
+				Name: &ast.Identifier{
+					Token: thisToken,
+					Value: "this",
+				},
+				Type: receiverType,
+			}
+		} else {
+			receiverName := p.parseIdentifier()
+			receiverType := p.parseTypeAnnotation()
+			decl.Receiver = &ast.Receiver{
+				Name: receiverName,
+				Type: receiverType,
+			}
+		}
+	}
+
+	// Parse parameters (optional for methods with no parameters)
+	if p.check(lexer.TOKEN_LPAREN) {
+		p.advance() // consume '('
+		decl.Parameters = p.parseParameters()
+		p.consume(lexer.TOKEN_RPAREN, "expected ')' after function parameters")
+	} else {
+		decl.Parameters = []*ast.Parameter{}
+	}
+
+	// Parse return types
+	if !p.check(lexer.TOKEN_NEWLINE) && !p.check(lexer.TOKEN_INDENT) {
+		decl.Returns = p.parseReturnTypes()
+	}
+
+	p.skipNewlines()
+
+	// Parse function body
+	decl.Body = p.parseBlock()
+
+	return decl
+}
+
+func (p *Parser) parseParameters() []*ast.Parameter {
+	params := []*ast.Parameter{}
+
+	if p.check(lexer.TOKEN_RPAREN) {
+		return params
+	}
+
+	for {
+		paramName := p.parseIdentifier()
+		paramType := p.parseTypeAnnotation()
+
+		params = append(params, &ast.Parameter{
+			Name: paramName,
+			Type: paramType,
+		})
+
+		if !p.match(lexer.TOKEN_COMMA) {
+			break
+		}
+	}
+
+	return params
+}
+
+func (p *Parser) parseReturnTypes() []ast.TypeAnnotation {
+	returns := []ast.TypeAnnotation{}
+
+	// Single return type or multiple in parentheses
+	if p.check(lexer.TOKEN_LPAREN) {
+		p.advance() // consume '('
+		for {
+			returns = append(returns, p.parseTypeAnnotation())
+			if !p.match(lexer.TOKEN_COMMA) {
+				break
+			}
+		}
+		p.consume(lexer.TOKEN_RPAREN, "expected ')' after return types")
+	} else {
+		returns = append(returns, p.parseTypeAnnotation())
+	}
+
+	return returns
+}
+
+// ============================================================================
+// Type Annotation Parsing
+// ============================================================================
+
+func (p *Parser) parseTypeAnnotation() ast.TypeAnnotation {
+	switch p.peekToken().Type {
+	case lexer.TOKEN_REFERENCE:
+		token := p.advance()
+		elementType := p.parseTypeAnnotation()
+		return &ast.ReferenceType{
+			Token:       token,
+			ElementType: elementType,
+		}
+
+	case lexer.TOKEN_LIST:
+		token := p.advance()
+		p.consume(lexer.TOKEN_OF, "expected 'of' after 'list'")
+		elementType := p.parseTypeAnnotation()
+		return &ast.ListType{
+			Token:       token,
+			ElementType: elementType,
+		}
+
+	case lexer.TOKEN_MAP:
+		token := p.advance()
+		p.consume(lexer.TOKEN_OF, "expected 'of' after 'map'")
+		keyType := p.parseTypeAnnotation()
+		p.consume(lexer.TOKEN_TO, "expected 'to' after map key type")
+		valueType := p.parseTypeAnnotation()
+		return &ast.MapType{
+			Token:     token,
+			KeyType:   keyType,
+			ValueType: valueType,
+		}
+
+	case lexer.TOKEN_CHANNEL:
+		token := p.advance()
+		p.consume(lexer.TOKEN_OF, "expected 'of' after 'channel'")
+		elementType := p.parseTypeAnnotation()
+		return &ast.ChannelType{
+			Token:       token,
+			ElementType: elementType,
+		}
+
+	case lexer.TOKEN_ERROR:
+		// Special case: 'error' is a keyword but also a valid type name
+		token := p.advance()
+		return &ast.NamedType{
+			Token: token,
+			Name:  "error",
+		}
+
+	case lexer.TOKEN_IDENTIFIER:
+		token := p.advance()
+		// Check for primitive types
+		switch token.Lexeme {
+		case "int", "int8", "int16", "int32", "int64",
+			"uint", "uint8", "uint16", "uint32", "uint64",
+			"float32", "float64", "string", "bool", "byte", "rune":
+			return &ast.PrimitiveType{
+				Token: token,
+				Name:  token.Lexeme,
+			}
+		default:
+			return &ast.NamedType{
+				Token: token,
+				Name:  token.Lexeme,
+			}
+		}
+
+	default:
+		p.error(p.peekToken(), fmt.Sprintf("expected type annotation, got %s", p.peekToken().Type))
+		return nil
+	}
+}
+
+// ============================================================================
+// Statement Parsing
+// ============================================================================
+
+func (p *Parser) parseBlock() *ast.BlockStmt {
+	token := p.peekToken()
+	statements := []ast.Statement{}
+
+	if !p.match(lexer.TOKEN_INDENT) {
+		p.error(token, "expected indented block")
+		return &ast.BlockStmt{Token: token, Statements: statements}
+	}
+
+	for !p.check(lexer.TOKEN_DEDENT) && !p.isAtEnd() {
+		p.skipNewlines()
+		if p.check(lexer.TOKEN_DEDENT) {
+			break
+		}
+		if stmt := p.parseStatement(); stmt != nil {
+			statements = append(statements, stmt)
+		}
+	}
+
+	p.consume(lexer.TOKEN_DEDENT, "expected dedent after block")
+
+	return &ast.BlockStmt{
+		Token:      token,
+		Statements: statements,
+	}
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	p.skipNewlines()
+
+	switch p.peekToken().Type {
+	case lexer.TOKEN_RETURN:
+		return p.parseReturnStmt()
+	case lexer.TOKEN_IF:
+		return p.parseIfStmt()
+	case lexer.TOKEN_FOR:
+		return p.parseForStmt()
+	case lexer.TOKEN_DEFER:
+		return p.parseDeferStmt()
+	case lexer.TOKEN_GO:
+		return p.parseGoStmt()
+	case lexer.TOKEN_SEND:
+		return p.parseSendStmt()
+	default:
+		return p.parseExpressionOrAssignmentStmt()
+	}
+}
+
+func (p *Parser) parseReturnStmt() *ast.ReturnStmt {
+	token := p.advance() // consume 'return'
+
+	stmt := &ast.ReturnStmt{
+		Token:  token,
+		Values: []ast.Expression{},
+	}
+
+	// Check if there are return values
+	if !p.check(lexer.TOKEN_NEWLINE) && !p.check(lexer.TOKEN_DEDENT) && !p.isAtEnd() {
+		for {
+			stmt.Values = append(stmt.Values, p.parseExpression())
+			if !p.match(lexer.TOKEN_COMMA) {
+				break
+			}
+		}
+	}
+
+	p.skipNewlines()
+	return stmt
+}
+
+func (p *Parser) parseIfStmt() *ast.IfStmt {
+	token := p.advance() // consume 'if'
+
+	stmt := &ast.IfStmt{
+		Token:     token,
+		Condition: p.parseExpression(),
+	}
+
+	p.skipNewlines()
+	stmt.Consequence = p.parseBlock()
+	p.skipNewlines()
+
+	// Check for else/else if
+	if p.check(lexer.TOKEN_ELSE) {
+		elseToken := p.advance()
+		p.skipNewlines()
+
+		// Check for else if
+		if p.check(lexer.TOKEN_IF) {
+			stmt.Alternative = p.parseIfStmt()
+		} else {
+			stmt.Alternative = &ast.ElseStmt{
+				Token: elseToken,
+				Body:  p.parseBlock(),
+			}
+		}
+	}
+
+	p.skipNewlines()
+	return stmt
+}
+
+func (p *Parser) parseForStmt() ast.Statement {
+	token := p.advance() // consume 'for'
+
+	// Look ahead to determine which type of for loop
+	// for item in collection
+	// for index, item in collection
+	// for i from start to/through end
+	// for condition
+
+	savePos := p.pos
+	firstIdent := p.parseIdentifier()
+
+	if p.match(lexer.TOKEN_IN) {
+		// for item in collection
+		collection := p.parseExpression()
+		p.skipNewlines()
+		body := p.parseBlock()
+		return &ast.ForRangeStmt{
+			Token:      token,
+			Variable:   firstIdent,
+			Collection: collection,
+			Body:       body,
+		}
+	} else if p.match(lexer.TOKEN_COMMA) {
+		// for index, item in collection
+		secondIdent := p.parseIdentifier()
+		p.consume(lexer.TOKEN_IN, "expected 'in' after variable list")
+		collection := p.parseExpression()
+		p.skipNewlines()
+		body := p.parseBlock()
+		return &ast.ForRangeStmt{
+			Token:      token,
+			Index:      firstIdent,
+			Variable:   secondIdent,
+			Collection: collection,
+			Body:       body,
+		}
+	} else if p.match(lexer.TOKEN_FROM) {
+		// for i from start to/through end
+		startExpr := p.parseExpression()
+		through := false
+		if p.match(lexer.TOKEN_THROUGH) {
+			through = true
+		} else {
+			p.consume(lexer.TOKEN_TO, "expected 'to' or 'through' after start value")
+		}
+		endExpr := p.parseExpression()
+		p.skipNewlines()
+		body := p.parseBlock()
+		return &ast.ForNumericStmt{
+			Token:    token,
+			Variable: firstIdent,
+			Start:    startExpr,
+			End:      endExpr,
+			Through:  through,
+			Body:     body,
+		}
+	} else {
+		// for condition - backtrack and parse as expression
+		p.pos = savePos
+		condition := p.parseExpression()
+		p.skipNewlines()
+		body := p.parseBlock()
+		return &ast.ForConditionStmt{
+			Token:     token,
+			Condition: condition,
+			Body:      body,
+		}
+	}
+}
+
+func (p *Parser) parseDeferStmt() *ast.DeferStmt {
+	token := p.advance() // consume 'defer'
+
+	call, ok := p.parseExpression().(*ast.CallExpr)
+	if !ok {
+		p.error(token, "defer must be followed by a function call")
+		return nil
+	}
+
+	p.skipNewlines()
+	return &ast.DeferStmt{
+		Token: token,
+		Call:  call,
+	}
+}
+
+func (p *Parser) parseGoStmt() *ast.GoStmt {
+	token := p.advance() // consume 'go'
+
+	call, ok := p.parseExpression().(*ast.CallExpr)
+	if !ok {
+		p.error(token, "go must be followed by a function call")
+		return nil
+	}
+
+	p.skipNewlines()
+	return &ast.GoStmt{
+		Token: token,
+		Call:  call,
+	}
+}
+
+func (p *Parser) parseSendStmt() *ast.SendStmt {
+	token := p.advance() // consume 'send'
+
+	value := p.parseExpression()
+	p.consume(lexer.TOKEN_TO, "expected 'to' after value in send statement")
+	channel := p.parseExpression()
+
+	p.skipNewlines()
+	return &ast.SendStmt{
+		Token:   token,
+		Value:   value,
+		Channel: channel,
+	}
+}
+
+func (p *Parser) parseExpressionOrAssignmentStmt() ast.Statement {
+	expr := p.parseExpression()
+
+	// Check for assignment or walrus operator
+	if p.match(lexer.TOKEN_ASSIGN) {
+		// Regular assignment: x = value
+		value := p.parseExpression()
+		p.skipNewlines()
+		return &ast.AssignStmt{
+			Target: expr,
+			Value:  value,
+			Token:  p.previousToken(),
+		}
+	} else if p.match(lexer.TOKEN_WALRUS) {
+		// Variable declaration with inference: x := value
+		ident, ok := expr.(*ast.Identifier)
+		if !ok {
+			p.error(p.previousToken(), "walrus operator can only be used with identifiers")
+			return nil
+		}
+		value := p.parseExpression()
+		p.skipNewlines()
+		return &ast.VarDeclStmt{
+			Name:  ident,
+			Value: value,
+			Token: p.previousToken(),
+		}
+	}
+
+	p.skipNewlines()
+	return &ast.ExpressionStmt{Expression: expr}
+}
+
+// ============================================================================
+// Expression Parsing with Operator Precedence
+// ============================================================================
+
+// Precedence levels (lowest to highest):
+// 1. or
+// 2. pipe (|>)
+// 3. and
+// 4. comparison (==, !=, <, >, <=, >=)
+// 5. additive (+, -)
+// 6. multiplicative (*, /, %)
+// 7. unary (not, -)
+// 8. postfix (call, index, slice, method call)
+// 9. primary
+
+func (p *Parser) parseExpression() ast.Expression {
+	return p.parseOrExpr()
+}
+
+func (p *Parser) parseOrExpr() ast.Expression {
+	left := p.parsePipeExpr()
+
+	for p.match(lexer.TOKEN_OR) {
+		operator := p.previousToken()
+		right := p.parsePipeExpr()
+		left = &ast.BinaryExpr{
+			Token:    operator,
+			Left:     left,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parsePipeExpr() ast.Expression {
+	left := p.parseOnErrExpr()
+
+	for p.match(lexer.TOKEN_PIPE) {
+		operator := p.previousToken()
+		right := p.parseOnErrExpr()
+		left = &ast.PipeExpr{
+			Token: operator,
+			Left:  left,
+			Right: right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseOnErrExpr() ast.Expression {
+	left := p.parseAndExpr()
+
+	if p.match(lexer.TOKEN_ONERR) {
+		operator := p.previousToken()
+		handler := p.parseAndExpr()
+		return &ast.OnErrExpr{
+			Token:   operator,
+			Left:    left,
+			Handler: handler,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseAndExpr() ast.Expression {
+	left := p.parseComparisonExpr()
+
+	for p.match(lexer.TOKEN_AND) {
+		operator := p.previousToken()
+		right := p.parseComparisonExpr()
+		left = &ast.BinaryExpr{
+			Token:    operator,
+			Left:     left,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseComparisonExpr() ast.Expression {
+	left := p.parseAdditiveExpr()
+
+	for p.match(lexer.TOKEN_DOUBLE_EQUALS, lexer.TOKEN_NOT_EQUALS, lexer.TOKEN_LT, lexer.TOKEN_GT, lexer.TOKEN_LTE, lexer.TOKEN_GTE) {
+		operator := p.previousToken()
+		right := p.parseAdditiveExpr()
+		left = &ast.BinaryExpr{
+			Token:    operator,
+			Left:     left,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseAdditiveExpr() ast.Expression {
+	left := p.parseMultiplicativeExpr()
+
+	for p.match(lexer.TOKEN_PLUS, lexer.TOKEN_MINUS) {
+		operator := p.previousToken()
+		right := p.parseMultiplicativeExpr()
+		left = &ast.BinaryExpr{
+			Token:    operator,
+			Left:     left,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseMultiplicativeExpr() ast.Expression {
+	left := p.parseUnaryExpr()
+
+	for p.match(lexer.TOKEN_STAR, lexer.TOKEN_SLASH, lexer.TOKEN_PERCENT) {
+		operator := p.previousToken()
+		right := p.parseUnaryExpr()
+		left = &ast.BinaryExpr{
+			Token:    operator,
+			Left:     left,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return left
+}
+
+func (p *Parser) parseUnaryExpr() ast.Expression {
+	if p.match(lexer.TOKEN_NOT, lexer.TOKEN_MINUS) {
+		operator := p.previousToken()
+		right := p.parseUnaryExpr()
+		return &ast.UnaryExpr{
+			Token:    operator,
+			Operator: operator.Lexeme,
+			Right:    right,
+		}
+	}
+
+	return p.parsePostfixExpr()
+}
+
+func (p *Parser) parsePostfixExpr() ast.Expression {
+	expr := p.parsePrimaryExpr()
+
+	for {
+		switch {
+		case p.match(lexer.TOKEN_LPAREN):
+			// Function call
+			args := []ast.Expression{}
+			if !p.check(lexer.TOKEN_RPAREN) {
+				for {
+					args = append(args, p.parseExpression())
+					if !p.match(lexer.TOKEN_COMMA) {
+						break
+					}
+				}
+			}
+			p.consume(lexer.TOKEN_RPAREN, "expected ')' after arguments")
+			expr = &ast.CallExpr{
+				Token:     p.previousToken(),
+				Function:  expr,
+				Arguments: args,
+			}
+
+		case p.match(lexer.TOKEN_DOT):
+			// Method call or field access
+			dotToken := p.previousToken()
+			method := p.parseIdentifier()
+
+			if p.check(lexer.TOKEN_LPAREN) {
+				// Method call
+				p.advance() // consume '('
+				args := []ast.Expression{}
+				if !p.check(lexer.TOKEN_RPAREN) {
+					for {
+						args = append(args, p.parseExpression())
+						if !p.match(lexer.TOKEN_COMMA) {
+							break
+						}
+					}
+				}
+				p.consume(lexer.TOKEN_RPAREN, "expected ')' after arguments")
+				expr = &ast.MethodCallExpr{
+					Token:     dotToken,
+					Object:    expr,
+					Method:    method,
+					Arguments: args,
+				}
+			} else {
+				// Field access - treat as method call with no args for now
+				expr = &ast.MethodCallExpr{
+					Token:     dotToken,
+					Object:    expr,
+					Method:    method,
+					Arguments: []ast.Expression{},
+				}
+			}
+
+		case p.match(lexer.TOKEN_LBRACKET):
+			// Index or slice
+			if p.check(lexer.TOKEN_COLON) {
+				// Slice with no start: [:end]
+				p.advance() // consume ':'
+				end := p.parseExpression()
+				p.consume(lexer.TOKEN_RBRACKET, "expected ']' after slice")
+				expr = &ast.SliceExpr{
+					Token: p.previousToken(),
+					Left:  expr,
+					Start: nil,
+					End:   end,
+				}
+			} else {
+				first := p.parseExpression()
+				if p.match(lexer.TOKEN_COLON) {
+					// Slice: [start:end] or [start:]
+					var end ast.Expression
+					if !p.check(lexer.TOKEN_RBRACKET) {
+						end = p.parseExpression()
+					}
+					p.consume(lexer.TOKEN_RBRACKET, "expected ']' after slice")
+					expr = &ast.SliceExpr{
+						Token: p.previousToken(),
+						Left:  expr,
+						Start: first,
+						End:   end,
+					}
+				} else {
+					// Index: [index]
+					p.consume(lexer.TOKEN_RBRACKET, "expected ']' after index")
+					expr = &ast.IndexExpr{
+						Token: p.previousToken(),
+						Left:  expr,
+						Index: first,
+					}
+				}
+			}
+
+		case p.match(lexer.TOKEN_AS):
+			// Type cast
+			asToken := p.previousToken()
+			targetType := p.parseTypeAnnotation()
+			expr = &ast.TypeCastExpr{
+				Token:      asToken,
+				Expression: expr,
+				TargetType: targetType,
+			}
+
+		default:
+			return expr
+		}
+	}
+}
+
+func (p *Parser) parsePrimaryExpr() ast.Expression {
+	switch p.peekToken().Type {
+	case lexer.TOKEN_INTEGER:
+		return p.parseIntegerLiteral()
+	case lexer.TOKEN_FLOAT:
+		return p.parseFloatLiteral()
+	case lexer.TOKEN_STRING:
+		return p.parseStringLiteral()
+	case lexer.TOKEN_TRUE, lexer.TOKEN_FALSE:
+		return p.parseBooleanLiteral()
+	case lexer.TOKEN_IDENTIFIER:
+		return p.parseIdentifierOrStructLiteral()
+	case lexer.TOKEN_THIS:
+		token := p.advance()
+		return &ast.ThisExpr{Token: token}
+	case lexer.TOKEN_EMPTY:
+		return p.parseEmptyExpr()
+	case lexer.TOKEN_DISCARD:
+		token := p.advance()
+		return &ast.DiscardExpr{Token: token}
+	case lexer.TOKEN_ERROR:
+		return p.parseErrorExpr()
+	case lexer.TOKEN_MAKE:
+		return p.parseMakeExpr()
+	case lexer.TOKEN_CLOSE:
+		return p.parseCloseExpr()
+	case lexer.TOKEN_PANIC:
+		return p.parsePanicExpr()
+	case lexer.TOKEN_RECOVER:
+		token := p.advance()
+		return &ast.RecoverExpr{Token: token}
+	case lexer.TOKEN_RECEIVE:
+		return p.parseReceiveExpr()
+	case lexer.TOKEN_LBRACKET:
+		return p.parseListLiteral()
+	case lexer.TOKEN_LPAREN:
+		return p.parseGroupedExpression()
+	default:
+		p.error(p.peekToken(), fmt.Sprintf("unexpected token in expression: %s", p.peekToken().Type))
+		p.advance()
+		return nil
+	}
+}
+
+func (p *Parser) parseIdentifier() *ast.Identifier {
+	token := p.advance()
+	if token.Type != lexer.TOKEN_IDENTIFIER {
+		p.error(token, "expected identifier")
+		return nil
+	}
+	return &ast.Identifier{
+		Token: token,
+		Value: token.Lexeme,
+	}
+}
+
+func (p *Parser) parseIntegerLiteral() *ast.IntegerLiteral {
+	token := p.advance()
+	value, err := strconv.ParseInt(token.Lexeme, 10, 64)
+	if err != nil {
+		p.error(token, fmt.Sprintf("could not parse integer: %s", err))
+		return nil
+	}
+	return &ast.IntegerLiteral{
+		Token: token,
+		Value: value,
+	}
+}
+
+func (p *Parser) parseFloatLiteral() *ast.FloatLiteral {
+	token := p.advance()
+	value, err := strconv.ParseFloat(token.Lexeme, 64)
+	if err != nil {
+		p.error(token, fmt.Sprintf("could not parse float: %s", err))
+		return nil
+	}
+	return &ast.FloatLiteral{
+		Token: token,
+		Value: value,
+	}
+}
+
+func (p *Parser) parseStringLiteral() *ast.StringLiteral {
+	token := p.advance()
+
+	// Check for string interpolation
+	if strings.Contains(token.Lexeme, "{") {
+		// Has interpolation - we'll parse this in semantic analysis
+		return &ast.StringLiteral{
+			Token:        token,
+			Value:        token.Lexeme,
+			Interpolated: true,
+		}
+	}
+
+	return &ast.StringLiteral{
+		Token:        token,
+		Value:        token.Lexeme,
+		Interpolated: false,
+	}
+}
+
+func (p *Parser) parseBooleanLiteral() *ast.BooleanLiteral {
+	token := p.advance()
+	return &ast.BooleanLiteral{
+		Token: token,
+		Value: token.Type == lexer.TOKEN_TRUE,
+	}
+}
+
+func (p *Parser) parseIdentifierOrStructLiteral() ast.Expression {
+	// Could be an identifier or a struct literal (TypeName{field: value})
+	ident := p.parseIdentifier()
+
+	// Check for struct literal
+	if p.check(lexer.TOKEN_LBRACE) {
+		p.advance() // consume '{'
+
+		// Parse type from identifier
+		var typ ast.TypeAnnotation
+		switch ident.Value {
+		case "int", "int8", "int16", "int32", "int64",
+			"uint", "uint8", "uint16", "uint32", "uint64",
+			"float32", "float64", "string", "bool", "byte", "rune":
+			typ = &ast.PrimitiveType{
+				Token: ident.Token,
+				Name:  ident.Value,
+			}
+		default:
+			typ = &ast.NamedType{
+				Token: ident.Token,
+				Name:  ident.Value,
+			}
+		}
+
+		// Check for map literal: {key: value}
+		// vs struct literal: TypeName{field: value}
+		// We'll treat this as struct literal for now
+		fields := []*ast.FieldValue{}
+
+		if !p.check(lexer.TOKEN_RBRACE) {
+			for {
+				fieldName := p.parseIdentifier()
+				p.consume(lexer.TOKEN_COLON, "expected ':' after field name")
+				fieldValue := p.parseExpression()
+				fields = append(fields, &ast.FieldValue{
+					Name:  fieldName,
+					Value: fieldValue,
+				})
+
+				if p.match(lexer.TOKEN_COMMA) {
+					continue
+				}
+				break
+			}
+		}
+
+		p.consume(lexer.TOKEN_RBRACE, "expected '}' after struct literal")
+
+		return &ast.StructLiteralExpr{
+			Token:  ident.Token,
+			Type:   typ,
+			Fields: fields,
+		}
+	}
+
+	return ident
+}
+
+func (p *Parser) parseEmptyExpr() *ast.EmptyExpr {
+	token := p.advance() // consume 'empty'
+
+	expr := &ast.EmptyExpr{Token: token}
+
+	// Check for typed empty: empty Type
+	if !p.check(lexer.TOKEN_NEWLINE) && !p.check(lexer.TOKEN_COMMA) && !p.check(lexer.TOKEN_RPAREN) && !p.isAtEnd() {
+		expr.Type = p.parseTypeAnnotation()
+	}
+
+	return expr
+}
+
+func (p *Parser) parseErrorExpr() *ast.ErrorExpr {
+	token := p.advance() // consume 'error'
+	message := p.parseExpression()
+	return &ast.ErrorExpr{
+		Token:   token,
+		Message: message,
+	}
+}
+
+func (p *Parser) parseMakeExpr() *ast.MakeExpr {
+	token := p.advance() // consume 'make'
+	p.consume(lexer.TOKEN_LPAREN, "expected '(' after 'make'")
+
+	typ := p.parseTypeAnnotation()
+	args := []ast.Expression{}
+
+	if p.match(lexer.TOKEN_COMMA) {
+		for {
+			args = append(args, p.parseExpression())
+			if !p.match(lexer.TOKEN_COMMA) {
+				break
+			}
+		}
+	}
+
+	p.consume(lexer.TOKEN_RPAREN, "expected ')' after make arguments")
+
+	return &ast.MakeExpr{
+		Token: token,
+		Type:  typ,
+		Args:  args,
+	}
+}
+
+func (p *Parser) parseCloseExpr() *ast.CloseExpr {
+	token := p.advance() // consume 'close'
+	channel := p.parseExpression()
+	return &ast.CloseExpr{
+		Token:   token,
+		Channel: channel,
+	}
+}
+
+func (p *Parser) parsePanicExpr() *ast.PanicExpr {
+	token := p.advance() // consume 'panic'
+	message := p.parseExpression()
+	return &ast.PanicExpr{
+		Token:   token,
+		Message: message,
+	}
+}
+
+func (p *Parser) parseReceiveExpr() *ast.ReceiveExpr {
+	token := p.advance() // consume 'receive'
+	p.consume(lexer.TOKEN_FROM, "expected 'from' after 'receive'")
+	channel := p.parseExpression()
+	return &ast.ReceiveExpr{
+		Token:   token,
+		Channel: channel,
+	}
+}
+
+func (p *Parser) parseListLiteral() *ast.ListLiteralExpr {
+	token := p.advance() // consume '['
+
+	elements := []ast.Expression{}
+
+	if !p.check(lexer.TOKEN_RBRACKET) {
+		for {
+			elements = append(elements, p.parseExpression())
+			if !p.match(lexer.TOKEN_COMMA) {
+				break
+			}
+		}
+	}
+
+	p.consume(lexer.TOKEN_RBRACKET, "expected ']' after list elements")
+
+	return &ast.ListLiteralExpr{
+		Token:    token,
+		Elements: elements,
+	}
+}
+
+func (p *Parser) parseGroupedExpression() ast.Expression {
+	p.advance() // consume '('
+	expr := p.parseExpression()
+	p.consume(lexer.TOKEN_RPAREN, "expected ')' after expression")
+	return expr
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,707 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/duber000/kukicha/internal/ast"
+)
+
+func TestParseSimpleFunction(t *testing.T) {
+	input := `func Add(a int, b int) int
+    return a + b
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if len(program.Declarations) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(program.Declarations))
+	}
+
+	fn, ok := program.Declarations[0].(*ast.FunctionDecl)
+	if !ok {
+		t.Fatalf("expected FunctionDecl, got %T", program.Declarations[0])
+	}
+
+	if fn.Name.Value != "Add" {
+		t.Errorf("expected function name 'Add', got '%s'", fn.Name.Value)
+	}
+
+	if len(fn.Parameters) != 2 {
+		t.Errorf("expected 2 parameters, got %d", len(fn.Parameters))
+	}
+
+	if len(fn.Returns) != 1 {
+		t.Errorf("expected 1 return type, got %d", len(fn.Returns))
+	}
+}
+
+func TestParseTypeDeclaration(t *testing.T) {
+	input := `type Person
+    Name string
+    Age int
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if len(program.Declarations) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(program.Declarations))
+	}
+
+	typeDecl, ok := program.Declarations[0].(*ast.TypeDecl)
+	if !ok {
+		t.Fatalf("expected TypeDecl, got %T", program.Declarations[0])
+	}
+
+	if typeDecl.Name.Value != "Person" {
+		t.Errorf("expected type name 'Person', got '%s'", typeDecl.Name.Value)
+	}
+
+	if len(typeDecl.Fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(typeDecl.Fields))
+	}
+}
+
+func TestParseInterfaceDeclaration(t *testing.T) {
+	input := `interface Writer
+    Write(data string) (int, error)
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if len(program.Declarations) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(program.Declarations))
+	}
+
+	ifaceDecl, ok := program.Declarations[0].(*ast.InterfaceDecl)
+	if !ok {
+		t.Fatalf("expected InterfaceDecl, got %T", program.Declarations[0])
+	}
+
+	if ifaceDecl.Name.Value != "Writer" {
+		t.Errorf("expected interface name 'Writer', got '%s'", ifaceDecl.Name.Value)
+	}
+
+	if len(ifaceDecl.Methods) != 1 {
+		t.Fatalf("expected 1 method, got %d", len(ifaceDecl.Methods))
+	}
+
+	method := ifaceDecl.Methods[0]
+	if method.Name.Value != "Write" {
+		t.Errorf("expected method name 'Write', got '%s'", method.Name.Value)
+	}
+
+	if len(method.Parameters) != 1 {
+		t.Errorf("expected 1 parameter, got %d", len(method.Parameters))
+	}
+
+	if len(method.Returns) != 2 {
+		t.Errorf("expected 2 return types, got %d", len(method.Returns))
+	}
+}
+
+func TestParseMethodDeclaration(t *testing.T) {
+	input := `func Display on this Person
+    print("Name: {this.Name}")
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if len(program.Declarations) != 1 {
+		t.Fatalf("expected 1 declaration, got %d", len(program.Declarations))
+	}
+
+	fn, ok := program.Declarations[0].(*ast.FunctionDecl)
+	if !ok {
+		t.Fatalf("expected FunctionDecl, got %T", program.Declarations[0])
+	}
+
+	if fn.Name.Value != "Display" {
+		t.Errorf("expected method name 'Display', got '%s'", fn.Name.Value)
+	}
+
+	if fn.Receiver == nil {
+		t.Fatal("expected receiver, got nil")
+	}
+
+	if fn.Receiver.Name.Value != "this" {
+		t.Errorf("expected receiver name 'this', got '%s'", fn.Receiver.Name.Value)
+	}
+}
+
+func TestParseIfStatement(t *testing.T) {
+	input := `func Test(x int) string
+    if x > 10
+        return "big"
+    else
+        return "small"
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	if len(fn.Body.Statements) != 1 {
+		t.Fatalf("expected 1 statement, got %d", len(fn.Body.Statements))
+	}
+
+	ifStmt, ok := fn.Body.Statements[0].(*ast.IfStmt)
+	if !ok {
+		t.Fatalf("expected IfStmt, got %T", fn.Body.Statements[0])
+	}
+
+	if ifStmt.Condition == nil {
+		t.Error("expected condition, got nil")
+	}
+
+	if ifStmt.Consequence == nil {
+		t.Error("expected consequence, got nil")
+	}
+
+	if ifStmt.Alternative == nil {
+		t.Error("expected alternative, got nil")
+	}
+}
+
+func TestParseForRangeLoop(t *testing.T) {
+	input := `func Test(items list of int)
+    for item in items
+        print(item)
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	forStmt, ok := fn.Body.Statements[0].(*ast.ForRangeStmt)
+	if !ok {
+		t.Fatalf("expected ForRangeStmt, got %T", fn.Body.Statements[0])
+	}
+
+	if forStmt.Variable.Value != "item" {
+		t.Errorf("expected variable 'item', got '%s'", forStmt.Variable.Value)
+	}
+}
+
+func TestParseForNumericLoop(t *testing.T) {
+	input := `func Test()
+    for i from 0 to 10
+        print(i)
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	forStmt, ok := fn.Body.Statements[0].(*ast.ForNumericStmt)
+	if !ok {
+		t.Fatalf("expected ForNumericStmt, got %T", fn.Body.Statements[0])
+	}
+
+	if forStmt.Variable.Value != "i" {
+		t.Errorf("expected variable 'i', got '%s'", forStmt.Variable.Value)
+	}
+
+	if forStmt.Through {
+		t.Error("expected 'to' loop, got 'through'")
+	}
+}
+
+func TestParseBinaryExpression(t *testing.T) {
+	tests := []struct {
+		input    string
+		operator string
+	}{
+		{`func Test() int
+    return 1 + 2
+`, "+"},
+		{`func Test() int
+    return 1 - 2
+`, "-"},
+		{`func Test() int
+    return 1 * 2
+`, "*"},
+		{`func Test() int
+    return 1 / 2
+`, "/"},
+		{`func Test() bool
+    return 1 == 2
+`, "=="},
+		{`func Test() bool
+    return 1 != 2
+`, "!="},
+	}
+
+	for _, tt := range tests {
+		p, err := New(tt.input, "test.kuki")
+		if err != nil {
+			t.Fatalf("lexer error: %v", err)
+		}
+		program, errors := p.Parse()
+
+		if len(errors) > 0 {
+			t.Fatalf("parser errors for operator %s: %v", tt.operator, errors)
+		}
+
+		fn := program.Declarations[0].(*ast.FunctionDecl)
+		retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+		binExpr, ok := retStmt.Values[0].(*ast.BinaryExpr)
+		if !ok {
+			t.Fatalf("expected BinaryExpr, got %T", retStmt.Values[0])
+		}
+
+		if binExpr.Operator != tt.operator {
+			t.Errorf("expected operator '%s', got '%s'", tt.operator, binExpr.Operator)
+		}
+	}
+}
+
+func TestParsePipeExpression(t *testing.T) {
+	input := `func Test() string
+    return "hello" |> ToUpper()
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+	pipeExpr, ok := retStmt.Values[0].(*ast.PipeExpr)
+	if !ok {
+		t.Fatalf("expected PipeExpr, got %T", retStmt.Values[0])
+	}
+
+	if pipeExpr.Left == nil {
+		t.Error("expected left expression, got nil")
+	}
+
+	if pipeExpr.Right == nil {
+		t.Error("expected right expression, got nil")
+	}
+}
+
+func TestParseOnErrExpression(t *testing.T) {
+	input := `func Test() int
+    return ReadFile("test.txt") onerr 0
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+	onErrExpr, ok := retStmt.Values[0].(*ast.OnErrExpr)
+	if !ok {
+		t.Fatalf("expected OnErrExpr, got %T", retStmt.Values[0])
+	}
+
+	if onErrExpr.Left == nil {
+		t.Error("expected left expression, got nil")
+	}
+
+	if onErrExpr.Handler == nil {
+		t.Error("expected handler expression, got nil")
+	}
+}
+
+func TestParseListType(t *testing.T) {
+	input := `func Test(items list of string)
+    return items
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	param := fn.Parameters[0]
+
+	listType, ok := param.Type.(*ast.ListType)
+	if !ok {
+		t.Fatalf("expected ListType, got %T", param.Type)
+	}
+
+	elemType, ok := listType.ElementType.(*ast.PrimitiveType)
+	if !ok {
+		t.Fatalf("expected PrimitiveType for element, got %T", listType.ElementType)
+	}
+
+	if elemType.Name != "string" {
+		t.Errorf("expected element type 'string', got '%s'", elemType.Name)
+	}
+}
+
+func TestParseMapType(t *testing.T) {
+	input := `func Test(m map of string to int)
+    return m
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	param := fn.Parameters[0]
+
+	mapType, ok := param.Type.(*ast.MapType)
+	if !ok {
+		t.Fatalf("expected MapType, got %T", param.Type)
+	}
+
+	keyType, ok := mapType.KeyType.(*ast.PrimitiveType)
+	if !ok {
+		t.Fatalf("expected PrimitiveType for key, got %T", mapType.KeyType)
+	}
+
+	if keyType.Name != "string" {
+		t.Errorf("expected key type 'string', got '%s'", keyType.Name)
+	}
+
+	valType, ok := mapType.ValueType.(*ast.PrimitiveType)
+	if !ok {
+		t.Fatalf("expected PrimitiveType for value, got %T", mapType.ValueType)
+	}
+
+	if valType.Name != "int" {
+		t.Errorf("expected value type 'int', got '%s'", valType.Name)
+	}
+}
+
+func TestParseReferenceType(t *testing.T) {
+	input := `func Test(p reference Person)
+    return p
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	param := fn.Parameters[0]
+
+	refType, ok := param.Type.(*ast.ReferenceType)
+	if !ok {
+		t.Fatalf("expected ReferenceType, got %T", param.Type)
+	}
+
+	elemType, ok := refType.ElementType.(*ast.NamedType)
+	if !ok {
+		t.Fatalf("expected NamedType for element, got %T", refType.ElementType)
+	}
+
+	if elemType.Name != "Person" {
+		t.Errorf("expected element type 'Person', got '%s'", elemType.Name)
+	}
+}
+
+func TestParseImportDeclaration(t *testing.T) {
+	input := `import "fmt"
+import "strings" as str
+
+func Test()
+    print("hello")
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if len(program.Imports) != 2 {
+		t.Fatalf("expected 2 imports, got %d", len(program.Imports))
+	}
+
+	imp1 := program.Imports[0]
+	if imp1.Path.Value != "fmt" {
+		t.Errorf("expected import path 'fmt', got '%s'", imp1.Path.Value)
+	}
+
+	if imp1.Alias != nil {
+		t.Errorf("expected no alias for first import, got '%s'", imp1.Alias.Value)
+	}
+
+	imp2 := program.Imports[1]
+	if imp2.Path.Value != "strings" {
+		t.Errorf("expected import path 'strings', got '%s'", imp2.Path.Value)
+	}
+
+	if imp2.Alias == nil {
+		t.Error("expected alias for second import, got nil")
+	} else if imp2.Alias.Value != "str" {
+		t.Errorf("expected alias 'str', got '%s'", imp2.Alias.Value)
+	}
+}
+
+func TestParseLeafDeclaration(t *testing.T) {
+	input := `leaf main
+
+func Main()
+    print("hello")
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	if program.LeafDecl == nil {
+		t.Fatal("expected leaf declaration, got nil")
+	}
+
+	if program.LeafDecl.Name.Value != "main" {
+		t.Errorf("expected leaf name 'main', got '%s'", program.LeafDecl.Name.Value)
+	}
+}
+
+func TestParseComplexExpression(t *testing.T) {
+	input := `func Test() bool
+    return a + b * c > d and e or f
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+
+	// Should parse as: ((a + (b * c)) > d) and e) or f
+	// Top level should be 'or'
+	orExpr, ok := retStmt.Values[0].(*ast.BinaryExpr)
+	if !ok {
+		t.Fatalf("expected BinaryExpr at top level, got %T", retStmt.Values[0])
+	}
+
+	if orExpr.Operator != "or" {
+		t.Errorf("expected top-level operator 'or', got '%s'", orExpr.Operator)
+	}
+}
+
+func TestParseWalrusOperator(t *testing.T) {
+	input := `func Test()
+    x := 42
+    print(x)
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	varDecl, ok := fn.Body.Statements[0].(*ast.VarDeclStmt)
+	if !ok {
+		t.Fatalf("expected VarDeclStmt, got %T", fn.Body.Statements[0])
+	}
+
+	if varDecl.Name.Value != "x" {
+		t.Errorf("expected variable name 'x', got '%s'", varDecl.Name.Value)
+	}
+
+	intLit, ok := varDecl.Value.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("expected IntegerLiteral, got %T", varDecl.Value)
+	}
+
+	if intLit.Value != 42 {
+		t.Errorf("expected value 42, got %d", intLit.Value)
+	}
+}
+
+func TestParseMethodCall(t *testing.T) {
+	input := `func Test(s string) int
+    return s.Length()
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+
+	methodCall, ok := retStmt.Values[0].(*ast.MethodCallExpr)
+	if !ok {
+		t.Fatalf("expected MethodCallExpr, got %T", retStmt.Values[0])
+	}
+
+	if methodCall.Method.Value != "Length" {
+		t.Errorf("expected method name 'Length', got '%s'", methodCall.Method.Value)
+	}
+}
+
+func TestParseIndexExpression(t *testing.T) {
+	input := `func Test(items list of int) int
+    return items[0]
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+
+	indexExpr, ok := retStmt.Values[0].(*ast.IndexExpr)
+	if !ok {
+		t.Fatalf("expected IndexExpr, got %T", retStmt.Values[0])
+	}
+
+	intLit, ok := indexExpr.Index.(*ast.IntegerLiteral)
+	if !ok {
+		t.Fatalf("expected IntegerLiteral for index, got %T", indexExpr.Index)
+	}
+
+	if intLit.Value != 0 {
+		t.Errorf("expected index 0, got %d", intLit.Value)
+	}
+}
+
+func TestParseSliceExpression(t *testing.T) {
+	input := `func Test(items list of int) list of int
+    return items[1:3]
+`
+
+	p, err := New(input, "test.kuki")
+	if err != nil {
+		t.Fatalf("lexer error: %v", err)
+	}
+	program, errors := p.Parse()
+
+	if len(errors) > 0 {
+		t.Fatalf("parser errors: %v", errors)
+	}
+
+	fn := program.Declarations[0].(*ast.FunctionDecl)
+	retStmt := fn.Body.Statements[0].(*ast.ReturnStmt)
+
+	sliceExpr, ok := retStmt.Values[0].(*ast.SliceExpr)
+	if !ok {
+		t.Fatalf("expected SliceExpr, got %T", retStmt.Values[0])
+	}
+
+	if sliceExpr.Start == nil {
+		t.Error("expected start index, got nil")
+	}
+
+	if sliceExpr.End == nil {
+		t.Error("expected end index, got nil")
+	}
+}

--- a/internal/semantic/semantic.go
+++ b/internal/semantic/semantic.go
@@ -1,0 +1,850 @@
+package semantic
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/duber000/kukicha/internal/ast"
+)
+
+// Analyzer performs semantic analysis on the AST
+type Analyzer struct {
+	program    *ast.Program
+	symbolTable *SymbolTable
+	errors      []error
+	currentFunc *ast.FunctionDecl // Track current function for return type checking
+}
+
+// New creates a new semantic analyzer
+func New(program *ast.Program) *Analyzer {
+	return &Analyzer{
+		program:     program,
+		symbolTable: NewSymbolTable(),
+		errors:      []error{},
+	}
+}
+
+// Analyze performs semantic analysis on the program
+func (a *Analyzer) Analyze() []error {
+	// First pass: Collect all type and interface declarations
+	a.collectDeclarations()
+
+	// Second pass: Analyze function bodies and validate
+	a.analyzeDeclarations()
+
+	return a.errors
+}
+
+// collectDeclarations collects all top-level declarations
+func (a *Analyzer) collectDeclarations() {
+	for _, decl := range a.program.Declarations {
+		switch d := decl.(type) {
+		case *ast.TypeDecl:
+			a.collectTypeDecl(d)
+		case *ast.InterfaceDecl:
+			a.collectInterfaceDecl(d)
+		case *ast.FunctionDecl:
+			a.collectFunctionDecl(d)
+		}
+	}
+}
+
+func (a *Analyzer) collectTypeDecl(decl *ast.TypeDecl) {
+	// Check export rules: PascalCase = exported, camelCase = unexported
+	if !isValidIdentifier(decl.Name.Value) {
+		a.error(decl.Name.Pos(), fmt.Sprintf("invalid type name '%s'", decl.Name.Value))
+		return
+	}
+
+	// Add type to symbol table
+	symbol := &Symbol{
+		Name:     decl.Name.Value,
+		Kind:     SymbolType,
+		Type:     &TypeInfo{Kind: TypeKindStruct, Name: decl.Name.Value},
+		Defined:  decl.Name.Pos(),
+		Exported: isExported(decl.Name.Value),
+	}
+
+	if err := a.symbolTable.Define(symbol); err != nil {
+		a.error(decl.Name.Pos(), err.Error())
+	}
+}
+
+func (a *Analyzer) collectInterfaceDecl(decl *ast.InterfaceDecl) {
+	// Check export rules
+	if !isValidIdentifier(decl.Name.Value) {
+		a.error(decl.Name.Pos(), fmt.Sprintf("invalid interface name '%s'", decl.Name.Value))
+		return
+	}
+
+	// Add interface to symbol table
+	symbol := &Symbol{
+		Name:     decl.Name.Value,
+		Kind:     SymbolInterface,
+		Type:     &TypeInfo{Kind: TypeKindInterface, Name: decl.Name.Value},
+		Defined:  decl.Name.Pos(),
+		Exported: isExported(decl.Name.Value),
+	}
+
+	if err := a.symbolTable.Define(symbol); err != nil {
+		a.error(decl.Name.Pos(), err.Error())
+	}
+}
+
+func (a *Analyzer) collectFunctionDecl(decl *ast.FunctionDecl) {
+	// Check export rules
+	if !isValidIdentifier(decl.Name.Value) {
+		a.error(decl.Name.Pos(), fmt.Sprintf("invalid function name '%s'", decl.Name.Value))
+		return
+	}
+
+	// Build function type
+	params := make([]*TypeInfo, len(decl.Parameters))
+	for i, param := range decl.Parameters {
+		params[i] = a.typeAnnotationToTypeInfo(param.Type)
+	}
+
+	returns := make([]*TypeInfo, len(decl.Returns))
+	for i, ret := range decl.Returns {
+		returns[i] = a.typeAnnotationToTypeInfo(ret)
+	}
+
+	funcType := &TypeInfo{
+		Kind:    TypeKindFunction,
+		Params:  params,
+		Returns: returns,
+	}
+
+	// Add function to symbol table
+	symbol := &Symbol{
+		Name:     decl.Name.Value,
+		Kind:     SymbolFunction,
+		Type:     funcType,
+		Defined:  decl.Name.Pos(),
+		Exported: isExported(decl.Name.Value),
+	}
+
+	if err := a.symbolTable.Define(symbol); err != nil {
+		a.error(decl.Name.Pos(), err.Error())
+	}
+}
+
+// analyzeDeclarations performs deep analysis of declarations
+func (a *Analyzer) analyzeDeclarations() {
+	for _, decl := range a.program.Declarations {
+		switch d := decl.(type) {
+		case *ast.TypeDecl:
+			a.analyzeTypeDecl(d)
+		case *ast.InterfaceDecl:
+			a.analyzeInterfaceDecl(d)
+		case *ast.FunctionDecl:
+			a.analyzeFunctionDecl(d)
+		}
+	}
+}
+
+func (a *Analyzer) analyzeTypeDecl(decl *ast.TypeDecl) {
+	// Validate field types exist
+	for _, field := range decl.Fields {
+		if !isValidIdentifier(field.Name.Value) {
+			a.error(field.Name.Pos(), fmt.Sprintf("invalid field name '%s'", field.Name.Value))
+		}
+
+		// Check that field type exists
+		a.validateTypeAnnotation(field.Type)
+	}
+}
+
+func (a *Analyzer) analyzeInterfaceDecl(decl *ast.InterfaceDecl) {
+	// Validate method signatures
+	for _, method := range decl.Methods {
+		if !isValidIdentifier(method.Name.Value) {
+			a.error(method.Name.Pos(), fmt.Sprintf("invalid method name '%s'", method.Name.Value))
+		}
+
+		// Validate parameter types
+		for _, param := range method.Parameters {
+			a.validateTypeAnnotation(param.Type)
+		}
+
+		// Validate return types
+		for _, ret := range method.Returns {
+			a.validateTypeAnnotation(ret)
+		}
+	}
+}
+
+func (a *Analyzer) analyzeFunctionDecl(decl *ast.FunctionDecl) {
+	// Enter new scope for function
+	a.symbolTable.EnterScope()
+	defer a.symbolTable.ExitScope()
+
+	// Track current function for return checking
+	a.currentFunc = decl
+
+	// Add receiver if present (for methods)
+	if decl.Receiver != nil {
+		a.validateTypeAnnotation(decl.Receiver.Type)
+
+		receiverSymbol := &Symbol{
+			Name:    decl.Receiver.Name.Value,
+			Kind:    SymbolParameter,
+			Type:    a.typeAnnotationToTypeInfo(decl.Receiver.Type),
+			Defined: decl.Receiver.Name.Pos(),
+		}
+		if err := a.symbolTable.Define(receiverSymbol); err != nil {
+			a.error(decl.Receiver.Name.Pos(), err.Error())
+		}
+	}
+
+	// Add parameters to scope
+	for _, param := range decl.Parameters {
+		if !isValidIdentifier(param.Name.Value) {
+			a.error(param.Name.Pos(), fmt.Sprintf("invalid parameter name '%s'", param.Name.Value))
+		}
+
+		a.validateTypeAnnotation(param.Type)
+
+		paramSymbol := &Symbol{
+			Name:    param.Name.Value,
+			Kind:    SymbolParameter,
+			Type:    a.typeAnnotationToTypeInfo(param.Type),
+			Defined: param.Name.Pos(),
+		}
+		if err := a.symbolTable.Define(paramSymbol); err != nil {
+			a.error(param.Name.Pos(), err.Error())
+		}
+	}
+
+	// Validate return types exist
+	for _, ret := range decl.Returns {
+		a.validateTypeAnnotation(ret)
+	}
+
+	// Analyze function body
+	if decl.Body != nil {
+		a.analyzeBlock(decl.Body)
+	}
+
+	a.currentFunc = nil
+}
+
+func (a *Analyzer) analyzeBlock(block *ast.BlockStmt) {
+	for _, stmt := range block.Statements {
+		a.analyzeStatement(stmt)
+	}
+}
+
+func (a *Analyzer) analyzeStatement(stmt ast.Statement) {
+	switch s := stmt.(type) {
+	case *ast.VarDeclStmt:
+		a.analyzeVarDeclStmt(s)
+	case *ast.AssignStmt:
+		a.analyzeAssignStmt(s)
+	case *ast.ReturnStmt:
+		a.analyzeReturnStmt(s)
+	case *ast.IfStmt:
+		a.analyzeIfStmt(s)
+	case *ast.ForRangeStmt:
+		a.analyzeForRangeStmt(s)
+	case *ast.ForNumericStmt:
+		a.analyzeForNumericStmt(s)
+	case *ast.ForConditionStmt:
+		a.analyzeForConditionStmt(s)
+	case *ast.DeferStmt:
+		a.analyzeExpression(s.Call)
+	case *ast.GoStmt:
+		a.analyzeExpression(s.Call)
+	case *ast.SendStmt:
+		a.analyzeExpression(s.Value)
+		a.analyzeExpression(s.Channel)
+	case *ast.ExpressionStmt:
+		a.analyzeExpression(s.Expression)
+	}
+}
+
+func (a *Analyzer) analyzeVarDeclStmt(stmt *ast.VarDeclStmt) {
+	if !isValidIdentifier(stmt.Name.Value) {
+		a.error(stmt.Name.Pos(), fmt.Sprintf("invalid variable name '%s'", stmt.Name.Value))
+	}
+
+	// Analyze value expression
+	valueType := a.analyzeExpression(stmt.Value)
+
+	// Type inference: use value type if no explicit type
+	var varType *TypeInfo
+	if stmt.Type != nil {
+		a.validateTypeAnnotation(stmt.Type)
+		varType = a.typeAnnotationToTypeInfo(stmt.Type)
+
+		// Check type compatibility
+		if !a.typesCompatible(varType, valueType) {
+			a.error(stmt.Pos(), fmt.Sprintf("cannot assign %s to %s", valueType, varType))
+		}
+	} else {
+		varType = valueType
+	}
+
+	// Add variable to symbol table
+	symbol := &Symbol{
+		Name:    stmt.Name.Value,
+		Kind:    SymbolVariable,
+		Type:    varType,
+		Defined: stmt.Name.Pos(),
+		Mutable: true,
+	}
+	if err := a.symbolTable.Define(symbol); err != nil {
+		a.error(stmt.Name.Pos(), err.Error())
+	}
+}
+
+func (a *Analyzer) analyzeAssignStmt(stmt *ast.AssignStmt) {
+	targetType := a.analyzeExpression(stmt.Target)
+	valueType := a.analyzeExpression(stmt.Value)
+
+	if !a.typesCompatible(targetType, valueType) {
+		a.error(stmt.Pos(), fmt.Sprintf("cannot assign %s to %s", valueType, targetType))
+	}
+}
+
+func (a *Analyzer) analyzeReturnStmt(stmt *ast.ReturnStmt) {
+	if a.currentFunc == nil {
+		a.error(stmt.Pos(), "return statement outside of function")
+		return
+	}
+
+	// Check return value count
+	if len(stmt.Values) != len(a.currentFunc.Returns) {
+		a.error(stmt.Pos(), fmt.Sprintf("expected %d return values, got %d", len(a.currentFunc.Returns), len(stmt.Values)))
+		return
+	}
+
+	// Check return value types
+	for i, value := range stmt.Values {
+		valueType := a.analyzeExpression(value)
+		expectedType := a.typeAnnotationToTypeInfo(a.currentFunc.Returns[i])
+
+		if !a.typesCompatible(expectedType, valueType) {
+			a.error(stmt.Pos(), fmt.Sprintf("cannot return %s as %s", valueType, expectedType))
+		}
+	}
+}
+
+func (a *Analyzer) analyzeIfStmt(stmt *ast.IfStmt) {
+	// Analyze condition
+	condType := a.analyzeExpression(stmt.Condition)
+	if condType.Kind != TypeKindBool && condType.Kind != TypeKindUnknown {
+		a.error(stmt.Pos(), "if condition must be boolean")
+	}
+
+	// Analyze consequence
+	a.symbolTable.EnterScope()
+	a.analyzeBlock(stmt.Consequence)
+	a.symbolTable.ExitScope()
+
+	// Analyze alternative
+	if stmt.Alternative != nil {
+		a.symbolTable.EnterScope()
+		switch alt := stmt.Alternative.(type) {
+		case *ast.ElseStmt:
+			a.analyzeBlock(alt.Body)
+		case *ast.IfStmt:
+			a.analyzeIfStmt(alt)
+		}
+		a.symbolTable.ExitScope()
+	}
+}
+
+func (a *Analyzer) analyzeForRangeStmt(stmt *ast.ForRangeStmt) {
+	// Analyze collection
+	collType := a.analyzeExpression(stmt.Collection)
+
+	a.symbolTable.EnterScope()
+	defer a.symbolTable.ExitScope()
+
+	// Add loop variables to scope
+	if stmt.Index != nil {
+		indexSymbol := &Symbol{
+			Name:    stmt.Index.Value,
+			Kind:    SymbolVariable,
+			Type:    &TypeInfo{Kind: TypeKindInt},
+			Defined: stmt.Index.Pos(),
+			Mutable: true,
+		}
+		a.symbolTable.Define(indexSymbol)
+	}
+
+	// Determine element type from collection type
+	var elemType *TypeInfo
+	if collType.Kind == TypeKindList && collType.ElementType != nil {
+		elemType = collType.ElementType
+	} else {
+		elemType = &TypeInfo{Kind: TypeKindUnknown}
+	}
+
+	varSymbol := &Symbol{
+		Name:    stmt.Variable.Value,
+		Kind:    SymbolVariable,
+		Type:    elemType,
+		Defined: stmt.Variable.Pos(),
+		Mutable: true,
+	}
+	a.symbolTable.Define(varSymbol)
+
+	// Analyze body
+	a.analyzeBlock(stmt.Body)
+}
+
+func (a *Analyzer) analyzeForNumericStmt(stmt *ast.ForNumericStmt) {
+	// Analyze start and end expressions
+	startType := a.analyzeExpression(stmt.Start)
+	endType := a.analyzeExpression(stmt.End)
+
+	if startType.Kind != TypeKindInt && startType.Kind != TypeKindUnknown {
+		a.error(stmt.Pos(), "for loop start must be int")
+	}
+	if endType.Kind != TypeKindInt && endType.Kind != TypeKindUnknown {
+		a.error(stmt.Pos(), "for loop end must be int")
+	}
+
+	a.symbolTable.EnterScope()
+	defer a.symbolTable.ExitScope()
+
+	// Add loop variable to scope
+	varSymbol := &Symbol{
+		Name:    stmt.Variable.Value,
+		Kind:    SymbolVariable,
+		Type:    &TypeInfo{Kind: TypeKindInt},
+		Defined: stmt.Variable.Pos(),
+		Mutable: true,
+	}
+	a.symbolTable.Define(varSymbol)
+
+	// Analyze body
+	a.analyzeBlock(stmt.Body)
+}
+
+func (a *Analyzer) analyzeForConditionStmt(stmt *ast.ForConditionStmt) {
+	// Analyze condition
+	condType := a.analyzeExpression(stmt.Condition)
+	if condType.Kind != TypeKindBool && condType.Kind != TypeKindUnknown {
+		a.error(stmt.Pos(), "for condition must be boolean")
+	}
+
+	a.symbolTable.EnterScope()
+	defer a.symbolTable.ExitScope()
+
+	// Analyze body
+	a.analyzeBlock(stmt.Body)
+}
+
+func (a *Analyzer) analyzeExpression(expr ast.Expression) *TypeInfo {
+	if expr == nil {
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		return a.analyzeIdentifier(e)
+	case *ast.IntegerLiteral:
+		return &TypeInfo{Kind: TypeKindInt}
+	case *ast.FloatLiteral:
+		return &TypeInfo{Kind: TypeKindFloat}
+	case *ast.StringLiteral:
+		if e.Interpolated {
+			a.analyzeStringInterpolation(e)
+		}
+		return &TypeInfo{Kind: TypeKindString}
+	case *ast.BooleanLiteral:
+		return &TypeInfo{Kind: TypeKindBool}
+	case *ast.BinaryExpr:
+		return a.analyzeBinaryExpr(e)
+	case *ast.UnaryExpr:
+		return a.analyzeUnaryExpr(e)
+	case *ast.PipeExpr:
+		return a.analyzePipeExpr(e)
+	case *ast.OnErrExpr:
+		return a.analyzeOnErrExpr(e)
+	case *ast.CallExpr:
+		return a.analyzeCallExpr(e)
+	case *ast.MethodCallExpr:
+		return a.analyzeMethodCallExpr(e)
+	case *ast.IndexExpr:
+		return a.analyzeIndexExpr(e)
+	case *ast.SliceExpr:
+		return a.analyzeSliceExpr(e)
+	case *ast.ListLiteralExpr:
+		return a.analyzeListLiteral(e)
+	case *ast.EmptyExpr:
+		if e.Type != nil {
+			return a.typeAnnotationToTypeInfo(e.Type)
+		}
+		return &TypeInfo{Kind: TypeKindUnknown}
+	case *ast.ThisExpr:
+		if a.currentFunc != nil && a.currentFunc.Receiver != nil {
+			return a.typeAnnotationToTypeInfo(a.currentFunc.Receiver.Type)
+		}
+		a.error(e.Pos(), "'this' used outside of method")
+		return &TypeInfo{Kind: TypeKindUnknown}
+	case *ast.MakeExpr:
+		return a.typeAnnotationToTypeInfo(e.Type)
+	case *ast.ReceiveExpr:
+		chanType := a.analyzeExpression(e.Channel)
+		if chanType.Kind == TypeKindChannel && chanType.ElementType != nil {
+			return chanType.ElementType
+		}
+		return &TypeInfo{Kind: TypeKindUnknown}
+	default:
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+}
+
+func (a *Analyzer) analyzeIdentifier(ident *ast.Identifier) *TypeInfo {
+	symbol := a.symbolTable.Resolve(ident.Value)
+	if symbol == nil {
+		a.error(ident.Pos(), fmt.Sprintf("undefined identifier '%s'", ident.Value))
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+	return symbol.Type
+}
+
+func (a *Analyzer) analyzeBinaryExpr(expr *ast.BinaryExpr) *TypeInfo {
+	leftType := a.analyzeExpression(expr.Left)
+	rightType := a.analyzeExpression(expr.Right)
+
+	switch expr.Operator {
+	case "+", "-", "*", "/", "%":
+		// Arithmetic operators
+		if !isNumericType(leftType) || !isNumericType(rightType) {
+			a.error(expr.Pos(), fmt.Sprintf("cannot apply %s to %s and %s", expr.Operator, leftType, rightType))
+		}
+		// Result type is the wider of the two
+		if leftType.Kind == TypeKindFloat || rightType.Kind == TypeKindFloat {
+			return &TypeInfo{Kind: TypeKindFloat}
+		}
+		return &TypeInfo{Kind: TypeKindInt}
+
+	case "==", "!=", "<", ">", "<=", ">=":
+		// Comparison operators
+		if !a.typesCompatible(leftType, rightType) {
+			a.error(expr.Pos(), fmt.Sprintf("cannot compare %s and %s", leftType, rightType))
+		}
+		return &TypeInfo{Kind: TypeKindBool}
+
+	case "and", "or":
+		// Logical operators
+		if leftType.Kind != TypeKindBool || rightType.Kind != TypeKindBool {
+			a.error(expr.Pos(), fmt.Sprintf("logical operator requires boolean operands"))
+		}
+		return &TypeInfo{Kind: TypeKindBool}
+
+	default:
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+}
+
+func (a *Analyzer) analyzeUnaryExpr(expr *ast.UnaryExpr) *TypeInfo {
+	rightType := a.analyzeExpression(expr.Right)
+
+	switch expr.Operator {
+	case "-":
+		if !isNumericType(rightType) {
+			a.error(expr.Pos(), "unary minus requires numeric type")
+		}
+		return rightType
+	case "not":
+		if rightType.Kind != TypeKindBool && rightType.Kind != TypeKindUnknown {
+			a.error(expr.Pos(), "not operator requires boolean")
+		}
+		return &TypeInfo{Kind: TypeKindBool}
+	default:
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+}
+
+func (a *Analyzer) analyzePipeExpr(expr *ast.PipeExpr) *TypeInfo {
+	// Left side is piped as first argument to right side (which must be a call)
+	a.analyzeExpression(expr.Left)
+	return a.analyzeExpression(expr.Right)
+}
+
+func (a *Analyzer) analyzeOnErrExpr(expr *ast.OnErrExpr) *TypeInfo {
+	leftType := a.analyzeExpression(expr.Left)
+	a.analyzeExpression(expr.Handler)
+	// Returns the same type as left expression (the success case)
+	return leftType
+}
+
+func (a *Analyzer) analyzeCallExpr(expr *ast.CallExpr) *TypeInfo {
+	funcType := a.analyzeExpression(expr.Function)
+
+	// If it's a known function, validate arguments
+	if funcType.Kind == TypeKindFunction {
+		if len(expr.Arguments) != len(funcType.Params) {
+			a.error(expr.Pos(), fmt.Sprintf("expected %d arguments, got %d", len(funcType.Params), len(expr.Arguments)))
+		}
+
+		for i, arg := range expr.Arguments {
+			argType := a.analyzeExpression(arg)
+			if i < len(funcType.Params) && !a.typesCompatible(funcType.Params[i], argType) {
+				a.error(expr.Pos(), fmt.Sprintf("argument %d: cannot use %s as %s", i+1, argType, funcType.Params[i]))
+			}
+		}
+
+		// Return first return type (if any)
+		if len(funcType.Returns) > 0 {
+			return funcType.Returns[0]
+		}
+	}
+
+	return &TypeInfo{Kind: TypeKindUnknown}
+}
+
+func (a *Analyzer) analyzeMethodCallExpr(expr *ast.MethodCallExpr) *TypeInfo {
+	// Analyze object
+	a.analyzeExpression(expr.Object)
+
+	// Analyze arguments
+	for _, arg := range expr.Arguments {
+		a.analyzeExpression(arg)
+	}
+
+	// For now, return unknown - full method resolution requires more complex type system
+	return &TypeInfo{Kind: TypeKindUnknown}
+}
+
+func (a *Analyzer) analyzeIndexExpr(expr *ast.IndexExpr) *TypeInfo {
+	leftType := a.analyzeExpression(expr.Left)
+	indexType := a.analyzeExpression(expr.Index)
+
+	// Index must be int for lists
+	if leftType.Kind == TypeKindList {
+		if indexType.Kind != TypeKindInt && indexType.Kind != TypeKindUnknown {
+			a.error(expr.Pos(), "list index must be int")
+		}
+		if leftType.ElementType != nil {
+			return leftType.ElementType
+		}
+	}
+
+	// For maps, validate key type
+	if leftType.Kind == TypeKindMap {
+		if leftType.KeyType != nil && !a.typesCompatible(leftType.KeyType, indexType) {
+			a.error(expr.Pos(), fmt.Sprintf("cannot use %s as map key type %s", indexType, leftType.KeyType))
+		}
+		if leftType.ValueType != nil {
+			return leftType.ValueType
+		}
+	}
+
+	return &TypeInfo{Kind: TypeKindUnknown}
+}
+
+func (a *Analyzer) analyzeSliceExpr(expr *ast.SliceExpr) *TypeInfo {
+	leftType := a.analyzeExpression(expr.Left)
+
+	if expr.Start != nil {
+		startType := a.analyzeExpression(expr.Start)
+		if startType.Kind != TypeKindInt && startType.Kind != TypeKindUnknown {
+			a.error(expr.Pos(), "slice start must be int")
+		}
+	}
+
+	if expr.End != nil {
+		endType := a.analyzeExpression(expr.End)
+		if endType.Kind != TypeKindInt && endType.Kind != TypeKindUnknown {
+			a.error(expr.Pos(), "slice end must be int")
+		}
+	}
+
+	// Slicing a list returns the same list type
+	return leftType
+}
+
+func (a *Analyzer) analyzeListLiteral(expr *ast.ListLiteralExpr) *TypeInfo {
+	var elemType *TypeInfo
+
+	// Infer element type from first element
+	if len(expr.Elements) > 0 {
+		elemType = a.analyzeExpression(expr.Elements[0])
+
+		// Check all elements have compatible types
+		for i, elem := range expr.Elements[1:] {
+			et := a.analyzeExpression(elem)
+			if !a.typesCompatible(elemType, et) {
+				a.error(expr.Pos(), fmt.Sprintf("list element %d: incompatible type %s, expected %s", i+1, et, elemType))
+			}
+		}
+	} else if expr.Type != nil {
+		elemType = a.typeAnnotationToTypeInfo(expr.Type)
+	} else {
+		elemType = &TypeInfo{Kind: TypeKindUnknown}
+	}
+
+	return &TypeInfo{
+		Kind:        TypeKindList,
+		ElementType: elemType,
+	}
+}
+
+func (a *Analyzer) analyzeStringInterpolation(lit *ast.StringLiteral) {
+	// Parse string interpolations and validate expressions
+	re := regexp.MustCompile(`\{([^}]+)\}`)
+	matches := re.FindAllStringSubmatch(lit.Value, -1)
+
+	for _, match := range matches {
+		exprStr := match[1]
+		// For now, just validate it's not empty
+		// Full expression parsing would require parsing the expression string
+		if strings.TrimSpace(exprStr) == "" {
+			a.error(lit.Pos(), "empty expression in string interpolation")
+		}
+	}
+}
+
+// validateTypeAnnotation checks that a type annotation is valid
+func (a *Analyzer) validateTypeAnnotation(typeAnn ast.TypeAnnotation) {
+	switch t := typeAnn.(type) {
+	case *ast.NamedType:
+		// Check that the type exists
+		symbol := a.symbolTable.Resolve(t.Name)
+		if symbol == nil || (symbol.Kind != SymbolType && symbol.Kind != SymbolInterface) {
+			a.error(t.Pos(), fmt.Sprintf("undefined type '%s'", t.Name))
+		}
+	case *ast.ReferenceType:
+		a.validateTypeAnnotation(t.ElementType)
+	case *ast.ListType:
+		a.validateTypeAnnotation(t.ElementType)
+	case *ast.MapType:
+		a.validateTypeAnnotation(t.KeyType)
+		a.validateTypeAnnotation(t.ValueType)
+	case *ast.ChannelType:
+		a.validateTypeAnnotation(t.ElementType)
+	}
+}
+
+// typeAnnotationToTypeInfo converts AST type annotation to TypeInfo
+func (a *Analyzer) typeAnnotationToTypeInfo(typeAnn ast.TypeAnnotation) *TypeInfo {
+	if typeAnn == nil {
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+
+	switch t := typeAnn.(type) {
+	case *ast.PrimitiveType:
+		return primitiveTypeFromString(t.Name)
+	case *ast.NamedType:
+		return &TypeInfo{Kind: TypeKindNamed, Name: t.Name}
+	case *ast.ReferenceType:
+		return &TypeInfo{
+			Kind:        TypeKindReference,
+			ElementType: a.typeAnnotationToTypeInfo(t.ElementType),
+		}
+	case *ast.ListType:
+		return &TypeInfo{
+			Kind:        TypeKindList,
+			ElementType: a.typeAnnotationToTypeInfo(t.ElementType),
+		}
+	case *ast.MapType:
+		return &TypeInfo{
+			Kind:      TypeKindMap,
+			KeyType:   a.typeAnnotationToTypeInfo(t.KeyType),
+			ValueType: a.typeAnnotationToTypeInfo(t.ValueType),
+		}
+	case *ast.ChannelType:
+		return &TypeInfo{
+			Kind:        TypeKindChannel,
+			ElementType: a.typeAnnotationToTypeInfo(t.ElementType),
+		}
+	default:
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+}
+
+// typesCompatible checks if two types are compatible
+func (a *Analyzer) typesCompatible(t1, t2 *TypeInfo) bool {
+	if t1 == nil || t2 == nil {
+		return false
+	}
+
+	// Unknown types are compatible with anything
+	if t1.Kind == TypeKindUnknown || t2.Kind == TypeKindUnknown {
+		return true
+	}
+
+	// Must be same kind
+	if t1.Kind != t2.Kind {
+		return false
+	}
+
+	// Check nested types for compound types
+	switch t1.Kind {
+	case TypeKindList, TypeKindChannel, TypeKindReference:
+		return a.typesCompatible(t1.ElementType, t2.ElementType)
+	case TypeKindMap:
+		return a.typesCompatible(t1.KeyType, t2.KeyType) && a.typesCompatible(t1.ValueType, t2.ValueType)
+	case TypeKindNamed:
+		return t1.Name == t2.Name
+	default:
+		return true
+	}
+}
+
+func (a *Analyzer) error(pos ast.Position, message string) {
+	err := fmt.Errorf("%s:%d:%d: %s", pos.File, pos.Line, pos.Column, message)
+	a.errors = append(a.errors, err)
+}
+
+// Helper functions
+
+func isValidIdentifier(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	// Must start with letter and contain only letters, digits, underscores
+	for i, r := range name {
+		if i == 0 {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_') {
+				return false
+			}
+		} else {
+			if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_') {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isExported(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	// Exported if starts with uppercase letter
+	r := rune(name[0])
+	return r >= 'A' && r <= 'Z'
+}
+
+func isNumericType(t *TypeInfo) bool {
+	return t.Kind == TypeKindInt || t.Kind == TypeKindFloat || t.Kind == TypeKindUnknown
+}
+
+func primitiveTypeFromString(name string) *TypeInfo {
+	switch name {
+	case "int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64":
+		return &TypeInfo{Kind: TypeKindInt}
+	case "float32", "float64":
+		return &TypeInfo{Kind: TypeKindFloat}
+	case "string":
+		return &TypeInfo{Kind: TypeKindString}
+	case "bool":
+		return &TypeInfo{Kind: TypeKindBool}
+	case "byte":
+		return &TypeInfo{Kind: TypeKindInt}
+	case "rune":
+		return &TypeInfo{Kind: TypeKindInt}
+	default:
+		return &TypeInfo{Kind: TypeKindUnknown}
+	}
+}

--- a/internal/semantic/symbols.go
+++ b/internal/semantic/symbols.go
@@ -1,0 +1,237 @@
+package semantic
+
+import (
+	"fmt"
+
+	"github.com/duber000/kukicha/internal/ast"
+)
+
+// SymbolKind represents the kind of symbol
+type SymbolKind int
+
+const (
+	SymbolVariable SymbolKind = iota
+	SymbolParameter
+	SymbolFunction
+	SymbolType
+	SymbolInterface
+)
+
+func (sk SymbolKind) String() string {
+	switch sk {
+	case SymbolVariable:
+		return "variable"
+	case SymbolParameter:
+		return "parameter"
+	case SymbolFunction:
+		return "function"
+	case SymbolType:
+		return "type"
+	case SymbolInterface:
+		return "interface"
+	default:
+		return "unknown"
+	}
+}
+
+// Symbol represents a symbol in the symbol table
+type Symbol struct {
+	Name     string
+	Kind     SymbolKind
+	Type     *TypeInfo
+	Defined  ast.Position
+	Mutable  bool
+	Exported bool
+}
+
+// TypeKind represents the kind of type
+type TypeKind int
+
+const (
+	TypeKindUnknown TypeKind = iota
+	TypeKindInt
+	TypeKindFloat
+	TypeKindString
+	TypeKindBool
+	TypeKindList
+	TypeKindMap
+	TypeKindChannel
+	TypeKindReference
+	TypeKindFunction
+	TypeKindStruct
+	TypeKindInterface
+	TypeKindNamed
+)
+
+func (tk TypeKind) String() string {
+	switch tk {
+	case TypeKindUnknown:
+		return "unknown"
+	case TypeKindInt:
+		return "int"
+	case TypeKindFloat:
+		return "float"
+	case TypeKindString:
+		return "string"
+	case TypeKindBool:
+		return "bool"
+	case TypeKindList:
+		return "list"
+	case TypeKindMap:
+		return "map"
+	case TypeKindChannel:
+		return "channel"
+	case TypeKindReference:
+		return "reference"
+	case TypeKindFunction:
+		return "function"
+	case TypeKindStruct:
+		return "struct"
+	case TypeKindInterface:
+		return "interface"
+	case TypeKindNamed:
+		return "named"
+	default:
+		return "unknown"
+	}
+}
+
+// TypeInfo represents type information
+type TypeInfo struct {
+	Kind        TypeKind
+	Name        string      // For named types
+	ElementType *TypeInfo   // For lists, channels, references
+	KeyType     *TypeInfo   // For maps
+	ValueType   *TypeInfo   // For maps
+	Params      []*TypeInfo // For functions
+	Returns     []*TypeInfo // For functions
+}
+
+func (ti *TypeInfo) String() string {
+	if ti == nil {
+		return "nil"
+	}
+
+	switch ti.Kind {
+	case TypeKindNamed:
+		return ti.Name
+	case TypeKindList:
+		if ti.ElementType != nil {
+			return fmt.Sprintf("list of %s", ti.ElementType)
+		}
+		return "list"
+	case TypeKindMap:
+		if ti.KeyType != nil && ti.ValueType != nil {
+			return fmt.Sprintf("map of %s to %s", ti.KeyType, ti.ValueType)
+		}
+		return "map"
+	case TypeKindChannel:
+		if ti.ElementType != nil {
+			return fmt.Sprintf("channel of %s", ti.ElementType)
+		}
+		return "channel"
+	case TypeKindReference:
+		if ti.ElementType != nil {
+			return fmt.Sprintf("reference %s", ti.ElementType)
+		}
+		return "reference"
+	case TypeKindFunction:
+		params := ""
+		for i, p := range ti.Params {
+			if i > 0 {
+				params += ", "
+			}
+			params += p.String()
+		}
+		returns := ""
+		for i, r := range ti.Returns {
+			if i > 0 {
+				returns += ", "
+			}
+			returns += r.String()
+		}
+		if returns != "" {
+			return fmt.Sprintf("func(%s) %s", params, returns)
+		}
+		return fmt.Sprintf("func(%s)", params)
+	default:
+		return ti.Kind.String()
+	}
+}
+
+// Scope represents a lexical scope
+type Scope struct {
+	parent  *Scope
+	symbols map[string]*Symbol
+}
+
+// NewScope creates a new scope
+func NewScope(parent *Scope) *Scope {
+	return &Scope{
+		parent:  parent,
+		symbols: make(map[string]*Symbol),
+	}
+}
+
+// Define adds a symbol to the current scope
+func (s *Scope) Define(symbol *Symbol) error {
+	if _, exists := s.symbols[symbol.Name]; exists {
+		return fmt.Errorf("identifier '%s' already declared in this scope", symbol.Name)
+	}
+	s.symbols[symbol.Name] = symbol
+	return nil
+}
+
+// Resolve looks up a symbol in the current scope and parent scopes
+func (s *Scope) Resolve(name string) *Symbol {
+	if symbol, ok := s.symbols[name]; ok {
+		return symbol
+	}
+	if s.parent != nil {
+		return s.parent.Resolve(name)
+	}
+	return nil
+}
+
+// SymbolTable manages scopes and symbols
+type SymbolTable struct {
+	scopes []*Scope
+}
+
+// NewSymbolTable creates a new symbol table
+func NewSymbolTable() *SymbolTable {
+	return &SymbolTable{
+		scopes: []*Scope{NewScope(nil)}, // Global scope
+	}
+}
+
+// CurrentScope returns the current scope
+func (st *SymbolTable) CurrentScope() *Scope {
+	if len(st.scopes) == 0 {
+		return nil
+	}
+	return st.scopes[len(st.scopes)-1]
+}
+
+// EnterScope creates a new scope
+func (st *SymbolTable) EnterScope() {
+	newScope := NewScope(st.CurrentScope())
+	st.scopes = append(st.scopes, newScope)
+}
+
+// ExitScope removes the current scope
+func (st *SymbolTable) ExitScope() {
+	if len(st.scopes) > 1 {
+		st.scopes = st.scopes[:len(st.scopes)-1]
+	}
+}
+
+// Define adds a symbol to the current scope
+func (st *SymbolTable) Define(symbol *Symbol) error {
+	return st.CurrentScope().Define(symbol)
+}
+
+// Resolve looks up a symbol
+func (st *SymbolTable) Resolve(name string) *Symbol {
+	return st.CurrentScope().Resolve(name)
+}


### PR DESCRIPTION
This commit implements the core kukicha compiler components:

**Parser (internal/parser/)**
- Complete AST node definitions for all language constructs
- Expression parser with proper operator precedence (or > pipe > and > comparison > additive > multiplicative > unary > postfix > primary)
- Statement parser supporting if/else, for loops (range, numeric, condition), defer, go
- Declaration parser for types, interfaces, and functions (including Kukicha-style methods)
- Comprehensive test suite with 20 passing tests

**Semantic Analyzer (internal/semantic/)**
- Symbol table with scope management
- Type checking and type inference for local variables
- Validation of type compatibility, return values, and undefined identifiers
- Export rules checking (PascalCase = exported, camelCase = unexported)
- String interpolation validation
- 12 passing tests covering various semantic checks

**Code Generator (internal/codegen/)**
- Transpiles AST to idiomatic Go code
- Type translation (list → []T, map → map[K]V, reference → *T, channel → chan T)
- String interpolation using fmt.Sprintf
- Automatic import generation (including fmt when needed)
- Proper indentation and formatting
- 13 passing tests verifying correct Go code generation

**CLI Tool (cmd/kukicha/)**
- `kukicha build <file>` - Compile Kukicha to Go and build binary
- `kukicha run <file>` - Transpile and execute
- `kukicha check <file>` - Type check without building
- `kukicha version` - Show version information

All tests pass (45 tests across 4 packages). The compiler successfully:
- Parses Kukicha syntax with indentation-based blocks
- Performs semantic analysis and type checking
- Generates clean, idiomatic Go code
- Provides a command-line interface for compilation