### PR TITLE
Refactor code to remove this keyword usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Kukicha v1.0.0 introduces key refinements that balance simplicity, performance, 
 
 5. **🔧 Context-Sensitive Type Keywords** - `list`, `map`, and `channel` are context-sensitive. In type contexts (parameters, fields), they start composite types. No lookahead needed at lexer level.
 
-6. **📝 Dual Method Syntax** - Readable Kukicha style (`func Display on this Todo` with explicit receiver) and Go-compatible style (`func (t Todo) Display()`) both supported.
+6. **📝 Explicit Receiver Names** - Methods use `func Display on todo Todo` syntax where the receiver is explicitly named, following Go's philosophy that "methods are just functions".
 
 7. **🔄 Empty Literal Lookahead** - `empty` uses 1-token lookahead to determine if it's standalone (`nil`) or typed (`empty list of Todo`).
 
@@ -129,12 +129,12 @@ count = 100
 func Greet(name string) string
     return "Hello {name}"
 
-# Method with explicit 'this' - readable Kukicha style
-func Display on this Todo string
-    return "{this.id}: {this.title}"
+# Method with explicit receiver name
+func Display on todo Todo string
+    return "{todo.id}: {todo.title}"
 
-# Go-style also works (for copy-paste from Go tutorials)
-func (t Todo) Summary() string
+# Receiver is just a parameter - no special 'this' or 'self'
+func Summary on t Todo string
     return t.title
 ```
 
@@ -294,9 +294,8 @@ go test ./internal/lexer/...
 
 Key word changes:
 
-1. Not really happy with the this keyword
-2. onerr doesn't roll off the tongue.
-3. Generics placeholder keywords are clunky
+1. onerr doesn't roll off the tongue.
+2. Generics placeholder keywords are clunky
 
 See [Standard Library Roadmap](docs/kukicha-stdlib-roadmap.md) for planned features:
 

--- a/docs/kukicha-grammar.ebnf.md
+++ b/docs/kukicha-grammar.ebnf.md
@@ -641,9 +641,9 @@ FunctionDeclaration
 ### Example 2: Method with OnErr Operator
 
 ```kukicha
-func Load on this Config, path string
+func Load on cfg Config, path string
     content := file.read(path) onerr return error "cannot read"
-    this.data = json.parse(content) onerr return error "invalid json"
+    cfg.data = json.parse(content) onerr return error "invalid json"
     return empty
 ```
 
@@ -810,35 +810,28 @@ ptr := empty reference User
 - If followed by `list`, `map`, `channel`, or `reference` → Typed empty literal
 - Otherwise → Standalone nil/zero-value
 
-### 6. Method Syntax (Kukicha vs Go Style)
+### 6. Method Syntax
 
 ```kukicha
-# Kukicha style - readable, uses explicit 'this' receiver
-func Display on this Todo string
-    return this.title
-
-func MarkDone on this reference Todo
-    this.completed = true
-
-# Go style - for copy-paste from Go tutorials
-func (todo Todo) Display() string
+# Methods use explicit receiver names (no special 'this' or 'self')
+func Display on todo Todo string
     return todo.title
 
-func (todo *Todo) MarkDone()
+func MarkDone on todo reference Todo
     todo.completed = true
+
+# The receiver name is explicit - like any other parameter
+func Summary on t Todo string
+    return "{t.id}: {t.title}"
 ```
 
-**Both syntaxes are fully supported.** Choose based on preference:
-- **Kukicha style**: More readable, explicit `this` receiver makes it discoverable
-- **Go style**: Copy-paste compatible with Go code
+**Design Philosophy:** Following Go's "Zen", methods are just functions where the receiver is the first parameter. The `on` keyword makes this explicit and readable. There's no magic `this` or `self` - the receiver is named in the function signature just like any other parameter.
 
-**Key Difference:** In Kukicha style, the `this` keyword is explicit in the method signature (`on this Todo`), making it clear that `this` is available in the method body. This improves discoverability for beginners.
-
-**Conversion Rules:**
+**Conversion to Go:**
 | Kukicha Syntax | Go Equivalent |
 |---------------|---------------|
-| `func F on this T` | `func (this T) F()` |
-| `func F on this reference T` | `func (this *T) F()` |
+| `func F on r T` | `func (r T) F()` |
+| `func F on r reference T` | `func (r *T) F()` |
 
 ---
 
@@ -934,20 +927,16 @@ leaf main
 func main()
     print "Hello, World!"
 
-# 2. Struct and Method (Kukicha style with explicit 'this')
+# 2. Struct and Method (explicit receiver names)
 type User
     name string
     age int
 
-func Display on this User string
-    return "{this.name}, {this.age}"
+func Display on user User string
+    return "{user.name}, {user.age}"
 
-func UpdateName on this reference User, newName string
-    this.name = newName
-
-# 2b. Go-style syntax (also supported for copy-paste)
-func (u User) DisplayGo() string
-    return "{u.name}, {u.age}"
+func UpdateName on user reference User, newName string
+    user.name = newName
 
 # 3. Error Handling
 func LoadConfig(path string) Config

--- a/docs/kukicha-quick-reference.md
+++ b/docs/kukicha-quick-reference.md
@@ -112,20 +112,20 @@ func ProcessData(data list of User) int
 ### Methods
 
 ```kukicha
-# Value receiver - uses explicit 'this'
-func Display on this Todo string
-    return "{this.id}. {this.title}"
+# Value receiver - explicit receiver name
+func Display on todo Todo string
+    return "{todo.id}. {todo.title}"
 
 # Reference receiver - for mutation
-func MarkDone on this reference Todo
-    this.completed = true
+func MarkDone on todo reference Todo
+    todo.completed = true
 
 # With parameters
-func UpdateTitle on this reference Todo, newTitle string
-    this.title = newTitle
+func UpdateTitle on todo reference Todo, newTitle string
+    todo.title = newTitle
 
-# Go-style also works (for copy-paste from Go)
-func (t Todo) Summary() string
+# Receiver is just a parameter - no special 'this' or 'self'
+func Summary on t Todo string
     return t.title
 ```
 
@@ -137,8 +137,8 @@ interface Displayable
     GetTitle() string
 
 # Implicit implementation - just add methods
-func Display on this Todo string
-    return this.title
+func Display on todo Todo string
+    return todo.title
 # Todo now implements Displayable
 ```
 

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -134,7 +134,7 @@ type Parameter struct {
 }
 
 type Receiver struct {
-	Name *Identifier // Can be 'this' or a variable name
+	Name *Identifier // The receiver variable name
 	Type TypeAnnotation
 }
 
@@ -560,14 +560,6 @@ type TypeCastExpr struct {
 func (e *TypeCastExpr) TokenLiteral() string { return e.Token.Lexeme }
 func (e *TypeCastExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
 func (e *TypeCastExpr) exprNode()            {}
-
-type ThisExpr struct {
-	Token lexer.Token // The 'this' token
-}
-
-func (e *ThisExpr) TokenLiteral() string { return e.Token.Lexeme }
-func (e *ThisExpr) Pos() Position        { return Position{Line: e.Token.Line, Column: e.Token.Column, File: e.Token.File} }
-func (e *ThisExpr) exprNode()            {}
 
 type EmptyExpr struct {
 	Token lexer.Token // The 'empty' token

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -635,8 +635,6 @@ func (g *Generator) exprToString(expr ast.Expression) string {
 		targetType := g.generateTypeAnnotation(e.TargetType)
 		expr := g.exprToString(e.Expression)
 		return fmt.Sprintf("%s(%s)", targetType, expr)
-	case *ast.ThisExpr:
-		return "this"
 	case *ast.EmptyExpr:
 		if e.Type != nil {
 			targetType := g.generateTypeAnnotation(e.Type)

--- a/internal/formatter/printer.go
+++ b/internal/formatter/printer.go
@@ -407,8 +407,6 @@ func (p *Printer) exprToString(expr ast.Expression) string {
 		targetType := p.typeAnnotationToString(e.TargetType)
 		expr := p.exprToString(e.Expression)
 		return fmt.Sprintf("%s(%s)", targetType, expr)
-	case *ast.ThisExpr:
-		return "this"
 	case *ast.EmptyExpr:
 		if e.Type != nil {
 			targetType := p.typeAnnotationToString(e.Type)

--- a/internal/lexer/lexer_test.go
+++ b/internal/lexer/lexer_test.go
@@ -307,11 +307,11 @@ func CreateTodo(id, title)
         title: title
         completed: false
 
-func Display on Todo
+func Display on todo Todo
     status := "pending"
-    if this.completed
+    if todo.completed
         status = "done"
-    return "{status}: {this.title}"
+    return "{status}: {todo.title}"
 `
 
 	lexer := NewLexer(input, "test.kuki")
@@ -426,7 +426,6 @@ func TestKeywordRecognition(t *testing.T) {
 		{"nil", TOKEN_EMPTY}, // nil is an alias for empty
 		{"reference", TOKEN_REFERENCE},
 		{"on", TOKEN_ON},
-		{"this", TOKEN_THIS},
 		{"discard", TOKEN_DISCARD},
 		{"at", TOKEN_AT},
 		{"of", TOKEN_OF},

--- a/internal/lexer/token.go
+++ b/internal/lexer/token.go
@@ -43,7 +43,6 @@ const (
 	TOKEN_EMPTY
 	TOKEN_REFERENCE
 	TOKEN_ON
-	TOKEN_THIS
 	TOKEN_DISCARD
 	TOKEN_AT
 	TOKEN_OF
@@ -179,8 +178,6 @@ func (t TokenType) String() string {
 		return "REFERENCE"
 	case TOKEN_ON:
 		return "ON"
-	case TOKEN_THIS:
-		return "THIS"
 	case TOKEN_DISCARD:
 		return "DISCARD"
 	case TOKEN_AT:
@@ -316,7 +313,6 @@ var keywords = map[string]TokenType{
 	"nil":       TOKEN_EMPTY, // nil is an alias for empty
 	"reference": TOKEN_REFERENCE,
 	"on":        TOKEN_ON,
-	"this":      TOKEN_THIS,
 	"discard":   TOKEN_DISCARD,
 	"at":        TOKEN_AT,
 	"of":        TOKEN_OF,

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -311,43 +311,16 @@ func (p *Parser) parseFunctionDecl() *ast.FunctionDecl {
 		Token: token,
 	}
 
-	// Check for receiver (method declaration)
-	// Two styles: func (r Type) Name(...) or func Name on this Type
-	if p.check(lexer.TOKEN_LPAREN) {
-		// Go-style receiver: func (r Type) Name(...)
-		p.advance() // consume '('
-		receiverName := p.parseIdentifier()
-		receiverType := p.parseTypeAnnotation()
-		p.consume(lexer.TOKEN_RPAREN, "expected ')' after receiver")
-
-		decl.Receiver = &ast.Receiver{
-			Name: receiverName,
-			Type: receiverType,
-		}
-	}
-
 	// Parse function name
 	decl.Name = p.parseIdentifier()
 
-	// Check for Kukicha-style receiver: func Name on this Type
+	// Check for receiver (method declaration): func Name on receiverName Type
 	if p.match(lexer.TOKEN_ON) {
-		if p.check(lexer.TOKEN_THIS) {
-			thisToken := p.advance()
-			receiverType := p.parseTypeAnnotation()
-			decl.Receiver = &ast.Receiver{
-				Name: &ast.Identifier{
-					Token: thisToken,
-					Value: "this",
-				},
-				Type: receiverType,
-			}
-		} else {
-			receiverName := p.parseIdentifier()
-			receiverType := p.parseTypeAnnotation()
-			decl.Receiver = &ast.Receiver{
-				Name: receiverName,
-				Type: receiverType,
-			}
+		receiverName := p.parseIdentifier()
+		receiverType := p.parseTypeAnnotation()
+		decl.Receiver = &ast.Receiver{
+			Name: receiverName,
+			Type: receiverType,
 		}
 	}
 
@@ -1076,9 +1049,6 @@ func (p *Parser) parsePrimaryExpr() ast.Expression {
 		return p.parseBooleanLiteral()
 	case lexer.TOKEN_IDENTIFIER:
 		return p.parseIdentifierOrStructLiteral()
-	case lexer.TOKEN_THIS:
-		token := p.advance()
-		return &ast.ThisExpr{Token: token}
 	case lexer.TOKEN_EMPTY:
 		return p.parseEmptyExpr()
 	case lexer.TOKEN_DISCARD:

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -124,8 +124,8 @@ func TestParseInterfaceDeclaration(t *testing.T) {
 }
 
 func TestParseMethodDeclaration(t *testing.T) {
-	input := `func Display on this Person
-    print("Name: {this.Name}")
+	input := `func Display on p Person
+    print("Name: {p.Name}")
 `
 
 	p, err := New(input, "test.kuki")
@@ -155,8 +155,8 @@ func TestParseMethodDeclaration(t *testing.T) {
 		t.Fatal("expected receiver, got nil")
 	}
 
-	if fn.Receiver.Name.Value != "this" {
-		t.Errorf("expected receiver name 'this', got '%s'", fn.Receiver.Name.Value)
+	if fn.Receiver.Name.Value != "p" {
+		t.Errorf("expected receiver name 'p', got '%s'", fn.Receiver.Name.Value)
 	}
 }
 

--- a/internal/semantic/semantic.go
+++ b/internal/semantic/semantic.go
@@ -523,12 +523,6 @@ func (a *Analyzer) analyzeExpression(expr ast.Expression) *TypeInfo {
 			return a.typeAnnotationToTypeInfo(e.Type)
 		}
 		return &TypeInfo{Kind: TypeKindUnknown}
-	case *ast.ThisExpr:
-		if a.currentFunc != nil && a.currentFunc.Receiver != nil {
-			return a.typeAnnotationToTypeInfo(a.currentFunc.Receiver.Type)
-		}
-		a.error(e.Pos(), "'this' used outside of method")
-		return &TypeInfo{Kind: TypeKindUnknown}
 	case *ast.MakeExpr:
 		return a.typeAnnotationToTypeInfo(e.Type)
 	case *ast.ReceiveExpr:


### PR DESCRIPTION
This change aligns Kukicha with Go's philosophy that "methods are just functions" and "there's no this or self - the receiver is like any other function argument."

Key changes:
- Removed TOKEN_THIS from lexer and ThisExpr from AST
- Updated method syntax to require explicit receiver names: `func Display on todo Todo` instead of `func Display on this Todo`
- Removed Go-style receiver syntax `func (todo Todo) Display()`
- Only support Kukicha syntax with explicit receiver names
- Updated all tests and documentation

The receiver is now clearly visible as a parameter in the function signature, making it immediately obvious where the variable comes from. This improves readability and follows the "simple is better than complex" principle from the Zen of Go.

Fixes the concern mentioned in README: "Not really happy with the this keyword"