### PR TITLE
docs: update stdlib roadmap for scripting focus with pipe-first design

### DIFF
--- a/docs/kukicha-stdlib-roadmap.md
+++ b/docs/kukicha-stdlib-roadmap.md
@@ -1,326 +1,712 @@
 # Kukicha Standard Library Roadmap
 
-**Version:** 2.0.0
-**Status:** Stable (Philosophy Shift)
-**Updated:** 2026-01-22
+**Version:** 3.0.0
+**Status:** Scripting-Focused
+**Updated:** 2026-01-23
 
 ---
 
-## Design Philosophy: "It's Just Go"
+## Design Philosophy: "Go for Scripts"
 
-Following CoffeeScript's successful approach with JavaScript, Kukicha adopts the principle: **"It's just Go."**
+Kukicha combines two powerful ideas:
 
-Kukicha provides syntactic sugar for Go, not a parallel standard library. You can use any Go package directly, and `onerr` handles error tuples at the call site.
+1. **"It's Just Go"** - Use any Go package directly with `onerr` for error handling
+2. **"Scripting Superpowers"** - Add high-level helpers for common scripting tasks
 
 **Key Principles:**
-- Go stdlib is first-class in Kukicha
-- Use `onerr` for error handling, not wrapper functions
-- Kukicha stdlib only for genuinely new capabilities Go lacks
-- No maintenance burden from tracking Go stdlib evolution
+- Go stdlib is first-class in Kukicha (no wrappers!)
+- Pipe operator `|>` makes data transformations readable
+- Kukicha stdlib provides scripting conveniences Go lacks
+- Perfect for one-off tools, automation scripts, and learning
+- All examples showcase pipe-based workflows
 
-See [kukicha-design-philosophy.md](kukicha-design-philosophy.md) for full rationale.
+**Target Use Cases:**
+- Fetching and processing API data
+- File manipulation and text processing
+- Building CLI tools quickly
+- Automation scripts (better than bash)
+- Learning programming concepts
 
 ---
 
 ## Implementation Status
 
-### ✅ Completed Packages (Value-Add)
+### ✅ Completed Packages
 
-These packages provide functionality Go lacks or make awkward:
+| Package | Purpose | Key Feature |
+|---------|---------|-------------|
+| **iter** | Functional iteration (Filter, Map, Reduce) | Lazy evaluation with pipes |
+| **slice** | Slice operations (First, Last, Drop, Unique) | Pipeline-friendly helpers |
+| **string** | String utilities | Thin wrappers for Go's strings package |
 
-| Package | Functions | Purpose |
-|---------|-----------|---------|
-| **iter** | 13 | Functional iteration (Filter, Map, Reduce) |
-| **slice** | 12 | Slice operations (First, Last, Drop, Unique) |
-| **string** | 28 | String utilities (thin wrappers, low maintenance) |
+### 🚧 Planned Scripting Packages (Priority Order)
 
-### ❌ Deprecated Plans
+These packages make Kukicha perfect for scripts and automation:
 
-The following were previously planned but are **no longer needed** under the CoffeeScript model:
-
-| Package | Reason | Use Instead |
-|---------|--------|-------------|
-| bytes | Go stdlib works directly | `import "bytes"` + `onerr` |
-| io | Go stdlib works directly | `import "io"` + `onerr` |
-| time | Go stdlib works directly | `import "time"` + `onerr` |
-| context | Go stdlib works directly | `import "context"` |
-| url | Go stdlib works directly | `import "net/url"` + `onerr` |
-| json | Go stdlib works directly | `import "encoding/json"` + `onerr` |
-| http | Go stdlib works directly | `import "net/http"` + `onerr` |
+| Package | Purpose | Status |
+|---------|---------|--------|
+| **fetch** | HTTP client optimized for pipes | Planned |
+| **parse** | JSON/YAML/CSV/TOML/XML parsing | Planned |
+| **cli** | CLI argument parsing made easy | Planned |
+| **files** | File operations with pipes | Planned |
+| **shell** | Safe command execution | Planned |
+| **template** | Text templating | Planned |
+| **retry** | Retry logic with backoff | Planned |
+| **result** | Optional/Result types (educational) | Planned |
 
 ---
 
-## Core Libraries
+## Completed Packages ✅
 
-### Iter Package ✅ COMPLETED
+### Iter Package
 
-Functional iteration operations using Go 1.23+ `iter.Seq`. Go's iterator protocol is low-level; we provide higher-level operations.
+Functional iteration with lazy evaluation and pipes:
 
 ```kukicha
 import "stdlib/iter"
-import "slices"
 
-# Lazy filtering and transformation
-result := slices.Values(numbers)
-    |> iter.Filter(func(n int) bool { return n > 0 })
-    |> iter.Map(func(n int) int { return n * 2 })
+# Pipeline: filter positive numbers, double them, sum
+total := numbers
+    |> iter.Filter(n -> n > 0)
+    |> iter.Map(n -> n * 2)
+    |> iter.Reduce(0, (acc, n) -> acc + n)
+
+# Find first matching item
+user := users
+    |> iter.Find(u -> u.Email equals "admin@example.com")
+    |> unwrapOr(createDefaultUser())
+
+# Take first 10, skip first 2
+page := items
+    |> iter.Skip(2)
+    |> iter.Take(10)
     |> iter.Collect()
 
 # Available functions:
-# - Filter, Map, FlatMap
-# - Take, Skip
-# - Enumerate, Zip
-# - Chunk
-# - Reduce, Collect
-# - Any, All, Find
+# Filter, Map, FlatMap, Take, Skip, Enumerate, Zip
+# Chunk, Reduce, Collect, Any, All, Find
 ```
 
-### Slice Package ✅ COMPLETED
+### Slice Package
 
-Extended slice operations Go lacks:
+Pipeline-friendly slice operations:
 
 ```kukicha
 import "stdlib/slice"
 
-# Take/drop operations
-firstThree := slice.First(items, 3)
-lastTwo := slice.Last(items, 2)
-tail := slice.Drop(items, 3)
-head := slice.DropLast(items, 1)
+# Clean and process data pipeline
+cleaned := rawData
+    |> slice.Drop(1)           # Remove header
+    |> slice.DropLast(1)       # Remove footer
+    |> slice.Filter(isValid)   # Keep valid items
+    |> slice.Unique()          # Remove duplicates
+    |> slice.Reverse()         # Newest first
 
-# Pipeline-friendly
-result := items
-    |> slice.Drop(2)
+# Extract and transform
+ids := users
+    |> slice.Map(u -> u.ID)
     |> slice.First(10)
-    |> process()
 
-# Additional operations
-reversed := slice.Reverse(items)
-unique := slice.Unique(items)
-chunked := slice.Chunk(items, 5)
+# Batch processing
+batches := items
+    |> slice.Chunk(100)
+    |> slice.Map(processBatch)
+
+# Available functions:
+# First, Last, Drop, DropLast, Reverse
+# Unique, Chunk, Filter, Map
 ```
 
-### String Package ✅ COMPLETED
+### String Package
 
-String utilities (thin wrappers with minimal maintenance burden):
+String operations designed for pipes:
 
 ```kukicha
 import "stdlib/string"
 
-# Case conversion
-upper := string.ToUpper("hello")
-lower := string.ToLower("WORLD")
+# Text processing pipeline
+result := rawText
+    |> string.TrimSpace()
+    |> string.ToLower()
+    |> string.ReplaceAll("_", "-")
+    |> string.Split("\n")
+    |> slice.Filter(line -> not string.IsEmpty(line))
 
-# Trimming
-trimmed := string.TrimSpace("  hello  ")
-withoutPrefix := string.TrimPrefix(url, "https://")
+# URL cleanup
+cleanUrl := url
+    |> string.TrimPrefix("https://")
+    |> string.TrimSuffix("/")
+    |> string.Split("/")
+    |> slice.Last(1)
 
-# Splitting and joining
-parts := string.Split("a,b,c", ",")
-joined := string.Join(parts, "|")
+# Available functions:
+# ToUpper, ToLower, TrimSpace, Trim, TrimPrefix, TrimSuffix
+# Split, Join, Contains, HasPrefix, HasSuffix, Replace, ReplaceAll
+```
 
-# Searching
-if string.Contains(text, "error")
-    handleError()
+---
+
+## Planned Scripting Packages 🚧
+
+These packages showcase the pipe operator and make scripting delightful:
+
+### Fetch Package (Planned)
+
+HTTP client designed for data pipelines:
+
+```kukicha
+import "stdlib/fetch"
+
+# Simple GET with automatic JSON parsing
+users := fetch.Get("https://api.github.com/users")
+    |> fetch.Json() as list of User
+    |> slice.Filter(u -> u.Followers > 100)
+    |> slice.Map(u -> u.Login)
+    onerr empty list of string
+
+# POST with JSON body
+response := user
+    |> fetch.JsonBody()
+    |> fetch.Post("https://api.example.com/users")
+    |> fetch.Text()
+    onerr "request failed"
+
+# Pipeline with headers and timeouts
+data := fetch.New("https://api.example.com/data")
+    |> fetch.Header("Authorization", "Bearer {token}")
+    |> fetch.Timeout(30.seconds)
+    |> fetch.Get()
+    |> fetch.Json() as Response
+    onerr panic "fetch failed"
+
+# Parallel fetching
+results := urls
+    |> slice.Map(url -> fetch.Get(url) |> fetch.Text())
+    |> waitAll()
+```
+
+### Parse Package (Planned)
+
+Universal parsing with pipes:
+
+```kukicha
+import "stdlib/parse"
+
+# JSON parsing pipeline
+config := "config.json"
+    |> files.Read()
+    |> parse.Json() as Config
+    |> validateConfig()
+    onerr defaultConfig()
+
+# CSV to structured data
+users := "data.csv"
+    |> files.Read()
+    |> parse.Csv()
+    |> slice.Drop(1)              # Skip header
+    |> slice.Map(csvRowToUser)
+    |> slice.Filter(u -> u.Active)
+
+# YAML config with validation
+settings := "settings.yaml"
+    |> files.Read()
+    |> parse.Yaml() as Settings
+    |> applyDefaults()
+    onerr panic "invalid settings"
+
+# TOML (like stem.toml)
+project := "stem.toml"
+    |> files.Read()
+    |> parse.Toml() as ProjectConfig
+
+# XML parsing
+feed := fetch.Get("https://example.com/rss")
+    |> parse.Xml() as RssFeed
+    |> extractItems()
+```
+
+### CLI Package (Planned)
+
+Build command-line tools easily:
+
+```kukicha
+import "stdlib/cli"
+
+func main()
+    app := cli.New("mytool")
+        |> cli.Description("A tool for processing data")
+        |> cli.Version("1.0.0")
+
+    app.Command("fetch")
+        |> cli.Arg("url", "URL to fetch")
+        |> cli.Flag("format", "Output format (json|text)", "json")
+        |> cli.Action(fetchCommand)
+
+    app.Command("process")
+        |> cli.Arg("input", "Input file")
+        |> cli.Flag("output", "Output file", "output.txt")
+        |> cli.Action(processCommand)
+
+    app.Run() onerr panic "command failed"
+
+func fetchCommand(args cli.Args)
+    url := args.String("url")
+    format := args.String("format")
+
+    data := fetch.Get(url)
+        |> fetch.Text()
+        onerr panic "fetch failed"
+
+    if format equals "json"
+        data |> parse.Json() |> print
+    else
+        print data
+```
+
+### Files Package (Planned)
+
+File operations optimized for pipes:
+
+```kukicha
+import "stdlib/files"
+
+# Read and process file
+output := "input.txt"
+    |> files.Read()
+    |> string.Split("\n")
+    |> slice.Filter(line -> not string.IsEmpty(line))
+    |> slice.Map(string.TrimSpace)
+    |> slice.Map(processLine)
+    |> string.Join("\n")
+    |> files.Write("output.txt")
+    onerr panic "processing failed"
+
+# Check if file exists
+if files.Exists("config.yaml")
+    loadConfig()
+else
+    createDefaultConfig()
+
+# List files with filtering
+logs := files.List("/var/log")
+    |> slice.Filter(f -> string.HasSuffix(f.Name, ".log"))
+    |> slice.Filter(f -> f.ModTime.After(yesterday))
+    |> slice.Map(f -> f.Path)
+
+# Watch for changes (useful for dev tools)
+files.Watch("./src/**/*.kuki", func(path string)
+    print "Changed: {path}"
+    rebuildProject()
+)
+
+# Temp file handling
+result := files.TempFile()
+    |> useWith(tempFile ->
+        tempFile |> files.Write(data)
+        processFile(tempFile.Path)
+    )  # Auto-deleted after use
+```
+
+### Shell Package (Planned)
+
+Safe command execution without shell injection:
+
+```kukicha
+import "stdlib/shell"
+
+# Run command and capture output
+output := shell.Run("git", "status")
+    |> shell.Output()
+    |> string.TrimSpace()
+    onerr "git failed"
+
+# Pipeline commands (safer than bash pipes)
+result := shell.Run("cat", "data.txt")
+    |> shell.Pipe(shell.Run("grep", "ERROR"))
+    |> shell.Pipe(shell.Run("wc", "-l"))
+    |> shell.Output()
+
+# Run with timeout and working directory
+exitCode := shell.New("npm", "install")
+    |> shell.Dir("./frontend")
+    |> shell.Timeout(5.minutes)
+    |> shell.Env("NODE_ENV", "production")
+    |> shell.Run()
+    |> shell.ExitCode()
+    onerr panic "npm install failed"
+
+# Stream output in real-time
+shell.Run("docker", "build", ".")
+    |> shell.Stdout(line -> print "[build] {line}")
+    |> shell.Stderr(line -> print "[error] {line}")
+    |> shell.Wait()
+    onerr panic "build failed"
+
+# Check if command exists
+if shell.Which("docker")
+    runDockerBuild()
+else
+    print "Docker not installed"
+```
+
+### Template Package (Planned)
+
+Text templating for code generation and reports:
+
+```kukicha
+import "stdlib/template"
+
+# Simple string templating
+email := template.Render("Hello {{.Name}}, your order #{{.OrderId}} is ready!")
+    |> template.Data(map of string to any{
+        "Name": user.Name,
+        "OrderId": order.Id,
+    })
+    onerr panic "template failed"
+
+# File-based templates
+report := "report.tmpl"
+    |> files.Read()
+    |> template.Parse()
+    |> template.Data(reportData)
+    |> template.Render()
+    |> files.Write("report.html")
+
+# Code generation
+code := template.New()
+    |> template.AddFunc("title", string.ToTitle)
+    |> template.Parse(codeTemplate)
+    |> template.Data(structDef)
+    |> template.Render()
+    |> files.Write("generated.go")
+```
+
+### Retry Package (Planned)
+
+Retry logic with exponential backoff:
+
+```kukicha
+import "stdlib/retry"
+
+# Retry with default backoff (3 attempts)
+data := retry.Do(func() any {
+        return fetch.Get(apiUrl) |> fetch.Json()
+    })
+    onerr panic "all retries failed"
+
+# Custom retry strategy
+result := retry.New()
+    |> retry.Attempts(5)
+    |> retry.Delay(1.second)
+    |> retry.Backoff(retry.Exponential)
+    |> retry.Do(func() any {
+        return processData()
+    })
+    onerr logError("processing failed after 5 attempts")
+
+# Retry with condition (only retry on specific errors)
+response := retry.DoIf(
+    func() any { return callExternalApi() },
+    func(err error) bool { return isRetryable(err) }
+)
+```
+
+### Result Package (Planned)
+
+Optional and Result types for educational purposes:
+
+```kukicha
+import "stdlib/result"
+
+# Optional type (better than empty/nil for beginners)
+user := findUserById(123)  # Returns Optional[User]
+
+if user.IsSome()
+    print "Found: {user.Unwrap().Name}"
+else
+    print "User not found"
+
+# Or use pipeline
+message := findUserById(123)
+    |> result.Map(u -> "Hello, {u.Name}")
+    |> result.UnwrapOr("User not found")
+
+# Result type (explicit error handling)
+data := parseConfig("config.yaml")  # Returns Result[Config, Error]
+
+config := data
+    |> result.MapErr(e -> "Config error: {e}")
+    |> result.Unwrap()
+    onerr defaultConfig()
+
+# Chaining operations
+output := result.Ok(initialData)
+    |> result.AndThen(validate)
+    |> result.AndThen(transform)
+    |> result.AndThen(save)
+    |> result.Match(
+        ok: d -> "Success: saved {d.Id}",
+        err: e -> "Failed: {e}"
+    )
+```
+
+---
+
+## Real-World Scripting Examples
+
+These examples show how Kukicha excels at practical automation:
+
+### Example 1: API Data Processing Script
+
+```kukicha
+import "stdlib/fetch"
+import "stdlib/parse"
+import "stdlib/files"
+
+# Fetch GitHub repos, filter active ones, save to JSON
+func main()
+    repos := fetch.Get("https://api.github.com/users/golang/repos")
+        |> fetch.Json() as list of Repo
+        |> slice.Filter(r -> not r.Archived)
+        |> slice.Filter(r -> r.Stars > 100)
+        |> slice.Map(r -> RepoSummary{
+            Name: r.Name,
+            Stars: r.Stars,
+            Url: r.HtmlUrl,
+        })
+        |> parse.ToJson()
+        |> files.Write("active-repos.json")
+        onerr panic "failed to process repos"
+
+    print "Saved {len(repos)} active repositories"
+```
+
+### Example 2: Log Analysis Tool
+
+```kukicha
+import "stdlib/files"
+import "stdlib/cli"
+
+func main()
+    app := cli.New("logparse")
+        |> cli.Arg("logfile", "Path to log file")
+        |> cli.Flag("level", "Filter by level (ERROR|WARN|INFO)", "ERROR")
+        |> cli.Action(analyzeLog)
+
+    app.Run() onerr panic "command failed"
+
+func analyzeLog(args cli.Args)
+    logPath := args.String("logfile")
+    level := args.String("level")
+
+    errors := logPath
+        |> files.Read()
+        |> string.Split("\n")
+        |> slice.Filter(line -> string.Contains(line, level))
+        |> slice.Map(parseLine)
+        |> slice.GroupBy(e -> e.ErrorCode)
+        |> summarize()
+
+    print "Found {len(errors)} {level} entries"
+    errors |> printSummary()
+```
+
+### Example 3: File Processing Pipeline
+
+```kukicha
+import "stdlib/files"
+import "stdlib/template"
+
+# Convert CSV to HTML report
+func main()
+    report := "sales.csv"
+        |> files.Read()
+        |> parse.Csv()
+        |> slice.Drop(1)              # Remove header
+        |> slice.Map(csvToSale)
+        |> calculateTotals()
+        |> template.Render(reportTemplate)
+        |> files.Write("report.html")
+        onerr panic "report generation failed"
+
+    print "Report saved to report.html"
+```
+
+### Example 4: Deployment Automation
+
+```kukicha
+import "stdlib/shell"
+import "stdlib/files"
+
+func deploy(version string)
+    print "Building version {version}..."
+
+    # Build and test
+    shell.Run("go", "test", "./...")
+        |> shell.Dir("./backend")
+        |> shell.Must()
+
+    shell.Run("npm", "run", "build")
+        |> shell.Dir("./frontend")
+        |> shell.Must()
+
+    # Create deployment package
+    files.TempDir()
+        |> useWith(tmpDir ->
+            shell.Run("cp", "-r", "dist", tmpDir)
+            shell.Run("tar", "-czf", "deploy-{version}.tar.gz", tmpDir)
+        )
+
+    print "Deployment package ready: deploy-{version}.tar.gz"
 ```
 
 ---
 
 ## Using Go Standard Library Directly
 
-Use Go packages directly with pure Kukicha syntax:
+You can ALWAYS use Go packages directly with pipes and `onerr`:
 
-### JSON
-
-```kukicha
-import "encoding/json"
-
-type User struct
-    Name  string
-    Email string
-
-# Marshal with error handling
-func SaveUser(user User) error
-    data := json.Marshal(user) onerr return error
-    return os.WriteFile("user.json", data, 0644)
-
-# Unmarshal - using 'reference of' for address-of
-func LoadUser(path string) (User, error)
-    data := os.ReadFile(path) onerr return User{}, error
-    user := User{}
-    json.Unmarshal(data, reference of user) onerr return User{}, error
-    return user, empty
-
-# Convenience pattern - panic for scripts
-func MustLoadUser(path string) User
-    data := os.ReadFile(path) onerr panic "cannot read file"
-    user := User{}
-    json.Unmarshal(data, reference of user) onerr panic "invalid json"
-    return user
-```
-
-### HTTP
+### HTTP with Go stdlib
 
 ```kukicha
 import "net/http"
 import "encoding/json"
 import "io"
 
-# Simple GET
-func FetchData(url string) (list of byte, error)
-    resp := http.Get(url) onerr return empty, error
-    defer resp.Body.Close()
-    return io.ReadAll(resp.Body)
+# GET request pipeline
+users := http.Get("https://api.example.com/users")
+    |> checkStatus()
+    |> .Body
+    |> io.ReadAll()
+    |> parse.Json() as list of User
+    onerr empty list of User
 
-# GET with JSON decoding
-func FetchUsers(url string) (list of User, error)
-    resp := http.Get(url) onerr return empty, error
-    defer resp.Body.Close()
-
-    users := list of User{}
-    decoder := json.NewDecoder(resp.Body)
-    decoder.Decode(reference of users) onerr return empty, error
-    return users, empty
-
-# POST with JSON body
-func CreateUser(url string, user User) error
-    data := json.Marshal(user) onerr return error
-    resp := http.Post(url, "application/json", bytes.NewReader(data)) onerr return error
-    defer resp.Body.Close()
-
+func checkStatus(resp reference http.Response, err error) (reference http.Response, error)
+    if err != empty
+        return empty, err
     if resp.StatusCode >= 400
-        return fmt.Errorf("request failed: {resp.Status}")
-    return empty
+        return empty, error "request failed: {resp.Status}"
+    return resp, empty
 ```
 
-### HTTP Server
-
-```kukicha
-import "net/http"
-import "encoding/json"
-
-func main()
-    http.HandleFunc("/users", handleUsers)
-    http.HandleFunc("/users/", handleUser)  # Go 1.22+ path patterns
-
-    print "Server starting on :8080"
-    http.ListenAndServe(":8080", empty) onerr panic "server failed"
-
-func handleUsers(w http.ResponseWriter, r reference http.Request)
-    if r.Method equals "GET"
-        users := getAllUsers()
-        w.Header().Set("Content-Type", "application/json")
-        json.NewEncoder(w).Encode(users)
-    else if r.Method equals "POST"
-        user := User{}
-        json.NewDecoder(r.Body).Decode(reference of user) onerr
-            http.Error(w, "Invalid JSON", 400)
-            return
-        saveUser(user)
-        w.WriteHeader(201)
-```
-
-### File I/O
+### File I/O with Go stdlib
 
 ```kukicha
 import "os"
 import "bufio"
 
-# Read entire file
-func ReadConfig(path string) (list of byte, error)
-    return os.ReadFile(path)
+# Read lines and process
+output := "input.txt"
+    |> os.Open()
+    |> readLines()
+    |> slice.Filter(isValid)
+    |> slice.Map(transform)
+    |> string.Join("\n")
+    |> writeFile("output.txt")
+    onerr panic "processing failed"
 
-# Write file
-func WriteOutput(path string, data list of byte) error
-    return os.WriteFile(path, data, 0644)
-
-# Read lines
-func ReadLines(path string) (list of string, error)
-    file := os.Open(path) onerr return empty, error
+func readLines(file reference os.File) list of string
     defer file.Close()
-
     lines := list of string{}
     scanner := bufio.NewScanner(file)
     for scanner.Scan()
         lines = append(lines, scanner.Text())
-    return lines, scanner.Err()
-```
-
-### Time and Context
-
-```kukicha
-import "time"
-import "context"
-
-# Timeouts
-func FetchWithTimeout(url string) (list of byte, error)
-    ctx, cancel := context.WithTimeout(context.Background(), 30 * time.Second)
-    defer cancel()
-
-    req := http.NewRequestWithContext(ctx, "GET", url, empty) onerr return empty, error
-    resp := http.DefaultClient.Do(req) onerr return empty, error
-    defer resp.Body.Close()
-    return io.ReadAll(resp.Body)
-
-# Periodic tasks
-func StartWorker(interval time.Duration)
-    ticker := time.NewTicker(interval)
-    defer ticker.Stop()
-
-    for t in ticker.C
-        print "Tick at {t}"
-        doWork()
+    return lines
 ```
 
 ---
 
-## Future Directions
+## Design Rationale
 
-### Potential Value-Add Packages
+### Why Scripting Packages?
 
-If compelling use cases emerge, we may add:
+1. **Real Pain Point**: Go is verbose for one-off scripts
+2. **Pipe-First Design**: Every function works naturally in pipelines
+3. **Beginner-Friendly**: Hide common patterns (JSON parsing, HTTP, etc.)
+4. **Still Just Go**: All packages use Go stdlib underneath
+5. **Educational**: Great for learning programming concepts
 
-| Package | Potential Purpose |
-|---------|------------------|
-| **maps** | Map operations Go lacks (Filter, Keys, Values, Merge) |
-| **result** | Optional Result type for explicit error handling |
+### Why Not Wrap Everything?
 
-### Not Planned
+We provide high-level helpers for common patterns, but:
 
-These remain accessible via direct Go imports:
+- ✅ Provide: Helpers Go lacks (fetch.Json, files.Read piping)
+- ✅ Provide: Ergonomic patterns (retry, CLI parsing)
+- ❌ Don't wrap: Every Go stdlib function (maintenance hell)
+- ❌ Don't duplicate: Functionality Go already does well
 
-- Cloud SDKs (use AWS, GCP, Azure Go SDKs directly)
-- Database drivers (use standard Go drivers)
-- Testing (use Go's `testing` package)
-- AI/LLM clients (use official Go SDKs)
+### Comparison to Other Languages
+
+**vs Python:**
+- ✅ Kukicha: Compiled binary, Go speed, type safety
+- ✅ Python: Larger ecosystem, no compilation step
+
+**vs Bash:**
+- ✅ Kukicha: Type safe, readable, maintainable
+- ✅ Bash: Installed everywhere, ultimate compatibility
+
+**vs Go:**
+- ✅ Kukicha: Less verbose for scripts, pipes, better error handling
+- ✅ Go: More explicit, larger community, job market
 
 ---
 
-## Rationale: Why Not Wrappers?
+## Implementation Priorities
 
-The previous roadmap planned ~187 wrapper functions. This was abandoned because:
+To make Kukicha the best scripting language for beginners and automation:
 
-1. **Maintenance burden**: Go stdlib evolves; wrappers become stale
-2. **Incomplete coverage**: Always missing some function
-3. **Documentation overhead**: Two sets of docs to maintain
-4. **Blocking issues**: Tuple returns required compiler changes
-5. **No real benefit**: `onerr` handles errors elegantly already
+### Phase 1: Essential Scripting (Next)
+1. **fetch** - HTTP client (most requested, enables tons of examples)
+2. **parse** - JSON/YAML/CSV parsing (pairs with fetch)
+3. **files** - File operations (basic scripting need)
 
-CoffeeScript thrived by being "just JavaScript" - no parallel ecosystem. Kukicha follows the same path.
+### Phase 2: Tools & CLI (After Phase 1)
+4. **cli** - Argument parsing (build actual tools)
+5. **shell** - Safe command execution (automation scripts)
+6. **template** - Text generation (code gen, reports)
+
+### Phase 3: Advanced (Future)
+7. **retry** - Reliability patterns
+8. **result** - Educational type for learning FP concepts
 
 ---
 
 ## Contributing
 
-The stdlib is largely complete. Future contributions should focus on:
+We welcome contributions! Focus areas:
 
-1. **Improving existing packages** (iter, slice, string)
-2. **Documentation and examples** for using Go stdlib in Kukicha
-3. **Compiler improvements** (onerr patterns, syntax sugar)
+### High Priority:
+- **Implementing scripting packages** (fetch, parse, files, cli, shell)
+- **Writing examples** showcasing pipe-based workflows
+- **Tutorial content** for beginners learning programming
 
-For significant new stdlib packages, open an issue first to discuss whether it provides genuine value Go lacks.
+### Good Contributions:
+- Improving existing packages (iter, slice, string)
+- Documentation with real-world examples
+- Performance optimizations
+- Bug fixes
+
+### Guidelines:
+1. **Every function should work in pipes** - First parameter is data to transform
+2. **Error handling with `onerr`** - Return tuples, let users handle errors
+3. **Build on Go stdlib** - Don't reinvent wheels, provide convenience
+4. **Focus on scripting** - Use cases: automation, data processing, CLI tools
+5. **Beginner-friendly** - Clear names, good docs, simple APIs
 
 ---
 
-**Last Updated:** 2026-01-22
+## Success Metrics
+
+We'll know Kukicha stdlib is successful when:
+
+- ✅ Complete beginners can fetch API data and save to JSON in 10 lines
+- ✅ Go developers reach for Kukicha for one-off scripts
+- ✅ "Script it in Kukicha" blog posts appear
+- ✅ Educational content uses Kukicha for teaching
+- ✅ Someone says "I love the pipe operator" unprompted
+
+---
+
+**Last Updated:** 2026-01-23
 **Philosophy Document:** [kukicha-design-philosophy.md](kukicha-design-philosophy.md)
+**Target Users:** Beginners learning programming, Go developers writing scripts, automation enthusiasts


### PR DESCRIPTION
Major changes:
- Shift focus to practical scripting tasks (fetch, parse, cli, files, shell, template, retry)
- Heavy use of pipe operator in ALL examples
- Target users: beginners learning programming, Go devs writing scripts
- Remove infrastructure/DevOps positioning (Pulumi/Terraform fill that niche)
- Keep "It's Just Go" philosophy but add scripting conveniences
- All new packages designed for pipeline composition

New planned packages showcase Kukicha's strengths:
- fetch: HTTP client optimized for pipes
- parse: JSON/YAML/CSV/TOML/XML parsing
- cli: Easy command-line tool building
- files: File operations with pipes
- shell: Safe command execution
- template: Text templating for code gen
- retry: Retry logic with backoff
- result: Optional/Result types (educational)

Real-world examples demonstrate typical use cases:
- API data processing
- Log analysis tools
- File processing pipelines
- Deployment automation scripts

https://claude.ai/code/session_01MA6ahjKRXfdsmjfRXoET3P