### PR TITLE
Add print() builtin function and auto-import fmt package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 go.work
 
 # Compiled binaries
+kukicha
 
 # Temporary test files
 test_*.kuki

--- a/cmd/kukicha/main.go
+++ b/cmd/kukicha/main.go
@@ -43,7 +43,9 @@ func main() {
 		}
 		checkCommand(os.Args[2])
 	case "fmt":
-		fmtCommand(os.Args[2:])
+		// TODO: Implement fmtCommand
+		fmt.Println("Error: fmt command not yet implemented")
+		os.Exit(1)
 	case "version":
 		fmt.Printf("kukicha version %s\n", version)
 	case "help", "-h", "--help":

--- a/examples/hello.kuki
+++ b/examples/hello.kuki
@@ -1,9 +1,6 @@
 # Kukicha is a Go-compatible language with Python-like syntax.
 # Blocks are defined by indentation (must be 4 spaces).
 
-# Standard Go packages can be imported directly
-import "fmt"
-
 # Function declaration follows Go's type system
 # Note: No curly braces needed, just indentation
 func Greet(name string) string
@@ -12,5 +9,5 @@ func Greet(name string) string
 
 # The main function is the entry point of the program
 func main()
-    # You can call standard Go library functions
-    fmt.Println(Greet("World"))
+    # Built-in print() function automatically imports fmt
+    print(Greet("World"))

--- a/examples/hello_newbie.kuki
+++ b/examples/hello_newbie.kuki
@@ -1,10 +1,6 @@
 # This is a computer program written in Kukicha.
 # Lines starting with # are comments for humans to read; the computer ignores them.
 
-# "import" tells the computer we want to use a toolset called "fmt" (short for format).
-# This toolset lets us print text to the screen.
-import "fmt"
-
 # A "func" (function) is like a small recipe or a list of instructions.
 # We are naming this recipe "Greet".
 # It needs one ingredient: a "name", which must be text (called a "string").
@@ -22,6 +18,6 @@ func main()
     # Here we use the "Greet" recipe we wrote above, giving it the ingredient "World".
     # The result will be "Hello World".
 
-    # Then we use the "Println" tool from "fmt" to show that result on the screen.
-    # Note: In the future, you will be able to just use print("Hello World").
-    fmt.Println(Greet("World"))
+    # Then we use the built-in "print" function to show that result on the screen.
+    # The print function automatically imports the "fmt" package for you.
+    print(Greet("World"))

--- a/examples/variadic_example.kuki
+++ b/examples/variadic_example.kuki
@@ -6,7 +6,7 @@ import "fmt"
 # Simple variadic function - takes many values of any type
 func Print(many values)
     for _, v in values
-        fmt.Println(v)
+        print(v)
 
 # Typed variadic function - takes many integers
 func Sum(many numbers int) int
@@ -17,10 +17,10 @@ func Sum(many numbers int) int
 
 # Mixed parameters - regular + variadic
 func PrintLabeled(label string, many items string)
-    fmt.Println(label)
+    print(label)
     for _, item in items
         fmt.Print("  - ")
-        fmt.Println(item)
+        print(item)
 
 func main()
     # Test untyped variadic
@@ -29,7 +29,7 @@ func main()
     # Test typed variadic
     result := Sum(1, 2, 3, 4, 5)
     fmt.Print("Sum: ")
-    fmt.Println(result)
+    print(result)
 
     # Test mixed parameters
     PrintLabeled("Shopping List:", "Apples", "Bananas", "Oranges")

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -67,8 +67,8 @@ func (g *Generator) Generate() (string, error) {
 	// Generate package declaration
 	g.generatePackage()
 
-	// Generate imports (including auto-imports like fmt for string interpolation)
-	needsFmt := g.needsStringInterpolation()
+	// Generate imports (including auto-imports like fmt for string interpolation and print builtin)
+	needsFmt := g.needsStringInterpolation() || g.needsPrintBuiltin()
 	if len(g.program.Imports) > 0 || needsFmt || len(g.autoImports) > 0 {
 		g.writeLine("")
 		g.generateImports()
@@ -110,8 +110,8 @@ func (g *Generator) generateImports() {
 		imports[path] = alias
 	}
 
-	// Check if we need fmt for string interpolation
-	needsFmt := g.needsStringInterpolation()
+	// Check if we need fmt for string interpolation or print builtin
+	needsFmt := g.needsStringInterpolation() || g.needsPrintBuiltin()
 	if needsFmt {
 		imports["fmt"] = ""
 	}
@@ -937,6 +937,14 @@ func (g *Generator) generateOnErrExpr(expr *ast.OnErrExpr) string {
 
 func (g *Generator) generateCallExpr(expr *ast.CallExpr) string {
 	funcName := g.exprToString(expr.Function)
+
+	// Check if this is a print() builtin - transpile to fmt.Println()
+	if id, ok := expr.Function.(*ast.Identifier); ok {
+		if id.Value == "print" {
+			funcName = "fmt.Println"
+		}
+	}
+
 	args := make([]string, len(expr.Arguments))
 	for i, arg := range expr.Arguments {
 		args[i] = g.exprToString(arg)
@@ -1165,6 +1173,129 @@ func (g *Generator) checkExprForInterpolation(expr ast.Expression) bool {
 			if g.checkExprForInterpolation(arg) {
 				return true
 			}
+		}
+	}
+
+	return false
+}
+
+func (g *Generator) needsPrintBuiltin() bool {
+	// Check if any calls use the print() builtin
+	return g.checkProgramForPrint(g.program)
+}
+
+func (g *Generator) checkProgramForPrint(program *ast.Program) bool {
+	for _, decl := range program.Declarations {
+		if fn, ok := decl.(*ast.FunctionDecl); ok {
+			if fn.Body != nil && g.checkBlockForPrint(fn.Body) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *Generator) checkBlockForPrint(block *ast.BlockStmt) bool {
+	for _, stmt := range block.Statements {
+		if g.checkStmtForPrint(stmt) {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *Generator) checkStmtForPrint(stmt ast.Statement) bool {
+	switch s := stmt.(type) {
+	case *ast.VarDeclStmt:
+		for _, val := range s.Values {
+			if g.checkExprForPrint(val) {
+				return true
+			}
+		}
+		return false
+	case *ast.AssignStmt:
+		for _, val := range s.Values {
+			if g.checkExprForPrint(val) {
+				return true
+			}
+		}
+		return false
+	case *ast.ReturnStmt:
+		for _, val := range s.Values {
+			if g.checkExprForPrint(val) {
+				return true
+			}
+		}
+	case *ast.IfStmt:
+		if g.checkExprForPrint(s.Condition) {
+			return true
+		}
+		if s.Consequence != nil && g.checkBlockForPrint(s.Consequence) {
+			return true
+		}
+		if s.Alternative != nil {
+			return g.checkStmtForPrint(s.Alternative)
+		}
+	case *ast.ForRangeStmt:
+		if s.Body != nil {
+			return g.checkBlockForPrint(s.Body)
+		}
+	case *ast.ForNumericStmt:
+		if s.Body != nil {
+			return g.checkBlockForPrint(s.Body)
+		}
+	case *ast.ForConditionStmt:
+		if s.Body != nil {
+			return g.checkBlockForPrint(s.Body)
+		}
+	case *ast.ExpressionStmt:
+		return g.checkExprForPrint(s.Expression)
+	case *ast.DeferStmt:
+		if s.Call != nil {
+			return g.checkExprForPrint(s.Call)
+		}
+	case *ast.GoStmt:
+		if s.Call != nil {
+			return g.checkExprForPrint(s.Call)
+		}
+	}
+	return false
+}
+
+func (g *Generator) checkExprForPrint(expr ast.Expression) bool {
+	if expr == nil {
+		return false
+	}
+
+	switch e := expr.(type) {
+	case *ast.CallExpr:
+		// Check if this is a print() call
+		if id, ok := e.Function.(*ast.Identifier); ok {
+			if id.Value == "print" {
+				return true
+			}
+		}
+		// Also check arguments recursively
+		for _, arg := range e.Arguments {
+			if g.checkExprForPrint(arg) {
+				return true
+			}
+		}
+	case *ast.BinaryExpr:
+		return g.checkExprForPrint(e.Left) || g.checkExprForPrint(e.Right)
+	case *ast.UnaryExpr:
+		return g.checkExprForPrint(e.Right)
+	case *ast.MethodCallExpr:
+		for _, arg := range e.Arguments {
+			if g.checkExprForPrint(arg) {
+				return true
+			}
+		}
+	case *ast.PipeExpr:
+		return g.checkExprForPrint(e.Left) || g.checkExprForPrint(e.Right)
+	case *ast.FunctionLiteral:
+		if e.Body != nil {
+			return g.checkBlockForPrint(e.Body)
 		}
 	}
 

--- a/internal/semantic/semantic.go
+++ b/internal/semantic/semantic.go
@@ -583,6 +583,17 @@ func (a *Analyzer) analyzeExpression(expr ast.Expression) *TypeInfo {
 }
 
 func (a *Analyzer) analyzeIdentifier(ident *ast.Identifier) *TypeInfo {
+	// Check for builtin functions first
+	if ident.Value == "print" {
+		// print is a variadic builtin that accepts any types
+		return &TypeInfo{
+			Kind:     TypeKindFunction,
+			Params:   []*TypeInfo{{Kind: TypeKindUnknown}},
+			Variadic: true,
+			Returns:  nil, // print doesn't return anything
+		}
+	}
+
 	symbol := a.symbolTable.Resolve(ident.Value)
 	if symbol == nil {
 		a.error(ident.Pos(), fmt.Sprintf("undefined identifier '%s'", ident.Value))


### PR DESCRIPTION
## Summary
This PR introduces a `print()` builtin function to Kukicha that automatically transpiles to `fmt.Println()` in Go, eliminating the need for explicit `import "fmt"` statements in simple programs. This makes the language more beginner-friendly while maintaining compatibility with Go's standard library.

## Key Changes

- **Added `print()` builtin function**: Users can now call `print()` directly without importing fmt. The code generator automatically transpiles it to `fmt.Println()`.

- **Auto-import fmt for print builtin**: The code generator now detects usage of the `print()` function and automatically includes the fmt import when needed, similar to how it handles string interpolation.

- **Updated semantic analyzer**: Added builtin function recognition in the semantic analyzer so `print()` is recognized as a valid variadic function that accepts any types.

- **Updated examples**: Simplified `hello.kuki` and `hello_newbie.kuki` examples to use the new `print()` builtin instead of explicit `fmt.Println()` calls, making them more accessible to beginners.

- **Disabled fmt command**: Temporarily disabled the `fmt` command implementation with a TODO comment, as it's not yet ready.

- **Updated .gitignore**: Added `kukicha` binary to gitignore.

## Implementation Details

- The code generator now includes a `needsPrintBuiltin()` method that recursively scans the entire program AST to detect any calls to the `print()` function.
- When a `print()` call is detected during code generation, it's automatically transpiled to `fmt.Println()` in the generated Go code.
- The semantic analyzer recognizes `print` as a builtin variadic function that accepts arguments of any type and returns nothing.
- This approach maintains full Go compatibility while providing a simpler API for beginners.